### PR TITLE
Apply toString to the timeRemaining value in ExpiryIndicator.

### DIFF
--- a/src/elements/ExpiryIndicator.stories.ts
+++ b/src/elements/ExpiryIndicator.stories.ts
@@ -25,6 +25,14 @@ export const Info: Story = {
   },
 };
 
+export const DecimalUsage: Story = {
+  args: {
+    timeRemaining: 1.4,
+    warningThreshold: 1,
+    timeUnit: ExpiryUnitTypes.Minutes,
+  },
+};
+
 export const Warning: Story = {
   args: {
     timeRemaining: 5,

--- a/src/elements/ExpiryIndicator.vue
+++ b/src/elements/ExpiryIndicator.vue
@@ -18,6 +18,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const timeRemaining = toRef(() => props.timeRemaining);
 const warningThreshold = toRef(() => props.warningThreshold);
+const timeRemainingLabel = computed(() => timeRemaining.value.toString());
 const status = computed(() => {
   if (timeRemaining.value <= 0) {
     return "expired";
@@ -36,7 +37,7 @@ const status = computed(() => {
       <expiry-icon />
     </span>
     <span class="body">
-      {{ t(`expiryIndicator.${timeUnit}`, { 'n': timeRemaining }) }}
+      {{ t(`expiryIndicator.${timeUnit}`, { 'n': timeRemainingLabel }) }}
     </span>
   </div>
 </template>


### PR DESCRIPTION
Fixes #11 

I missed this in testing 😅. i18n expects strings, which works most of the time. But I'm guessing 0 and 1 point decimals have some weirdness associated with them in javascript. 

cc @micahilbery 