### PR TITLE
ignore dist folder and add watch script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 .DS_Store
 dist-ssr
+dist
 coverage
 *.local
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thunderbirdops/services-ui",
-  "version": "0.6.2",
+  "version": "0.6.1",
   "author": "Thunderbird",
   "type": "module",
   "license": "MPL-2.0",
@@ -17,6 +17,7 @@
     "dev": "vite",
     "build": "vite build --",
     "preview": "vite preview",
+    "watch": "vite build --watch",
     "test:unit": "vitest",
     "test:e2e": "playwright test",
     "build-only": "vite build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thunderbirdops/services-ui",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": "Thunderbird",
   "type": "module",
   "license": "MPL-2.0",


### PR DESCRIPTION
This PR includes:

* Added a new script command `"watch": "vite build --watch"` to the list of available npm scripts. This helps creating artifacts while making changes and auto executing the build command.
* Added `dist` to git ignore.
