### PR TITLE
Remove fonts.css from main.css and reference it directly for storybook.

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type {Preview} from "@storybook/vue3";
+import '@/assets/styles/fonts.css';
 import '@/assets/styles/main.css';
 import {withThemeByClassName, withThemeByDataAttribute} from "@storybook/addon-themes";
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ You can install the library by adding the following line as a dependency to your
 npm i @thunderbirdops/services-ui
 ```
 
+We recommend you pull in the `Inter` font separately.
+
 ## Library Development
 
 ### Storybook

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -1,5 +1,4 @@
 @import './colours.css';
-@import './fonts.css';
 @import './variables.css';
 
 /* Only for storybook */


### PR DESCRIPTION
Fixes #3 

This allows us to not package the font files, and also to not hardcode a path for the font files. Which is an issue in https://github.com/thunderbird/thunderbird-accounts. 

