### PR TITLE
Add localization to TextArea

### DIFF
--- a/src/elements/TextArea.vue
+++ b/src/elements/TextArea.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue';
+import { t } from '@/composable/i18n';
 
 const model = defineModel<string>();
 const isInvalid = ref(false);
@@ -78,6 +79,7 @@ const onChange = () => {
     <span v-if="isInvalid" class="help-label invalid">
       <!-- Placeholder -->
       Invalid input
+      {{ t('textArea.invalidInput') }}
     </span>
     <span v-else-if="help" class="help-label">
       {{ help }}

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -27,5 +27,8 @@
   "switchToggle": {
     "off": "Aus",
     "on": "An"
+  },
+  "textArea": {
+    "invalidInput": "Ungültige Eingabe"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -27,5 +27,8 @@
   "switchToggle": {
     "off": "Off",
     "on": "On"
+  },
+  "textArea": {
+    "invalidInput": "Invalid input"
   }
 }


### PR DESCRIPTION
Closes #41 

* Localizes the placholder text in TextArea component
* Provides English and German localizations

(German localization provided by Google translate, with confirmation from ChatGPT.)