### PR TITLE
Fix TextArea duplicated invalid text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thunderbirdops/services-ui",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": "Thunderbird",
   "type": "module",
   "license": "MPL-2.0",

--- a/src/elements/TextArea.stories.ts
+++ b/src/elements/TextArea.stories.ts
@@ -37,6 +37,28 @@ export const Required: Story = {
     default: 'Why is a hot dog a sandwich?',
     required: true,
   },
+  decorators: [
+    (story) => ({
+      components: { story },
+      template: `
+        <div>
+          <story />
+          <button @click="triggerInvalid">
+            Force trigger invalid state
+          </button>
+        </div>
+      `,
+      methods: {
+        triggerInvalid() {
+          const textarea = document.querySelector('textarea');
+          if (textarea) {
+            const invalidEvent = new Event('invalid', { bubbles: true });
+            textarea.dispatchEvent(invalidEvent);
+          }
+        }
+      }
+    })
+  ]
 };
 
 export const RequiredWithPlaceholder: Story = {

--- a/src/elements/TextArea.vue
+++ b/src/elements/TextArea.vue
@@ -78,7 +78,6 @@ const onChange = () => {
     </span>
     <span v-if="isInvalid" class="help-label invalid">
       <!-- Placeholder -->
-      Invalid input
       {{ t('textArea.invalidInput') }}
     </span>
     <span v-else-if="help" class="help-label">


### PR DESCRIPTION
## Description

- Removes hard-coded `Invalid Input` from the `TextArea` component invalid state
- Adds a button to force trigger the invalid state without needing a real form context
- Bumps the version to v.0.6.10 as this is just a bug fix

Before:
![image](https://github.com/user-attachments/assets/ad34c66a-13ab-497c-9a84-cbf4221a1517)

After:
![image](https://github.com/user-attachments/assets/fc41f969-c0c2-4451-b02b-e3b05fb465ad)


Fixes:
https://github.com/thunderbird/services-ui/issues/51