### PR TITLE
Fix / Expose reset from TextInput + Required from TextArea

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thunderbirdops/services-ui",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "author": "Thunderbird",
   "type": "module",
   "license": "MPL-2.0",

--- a/src/elements/TextArea.vue
+++ b/src/elements/TextArea.vue
@@ -57,7 +57,7 @@ const onChange = () => {
   <label class="wrapper" :for="name">
     <span class="label">
       <slot />
-      <span v-if="required && model?.length === 0" class="required">*</span>
+      <span v-if="required && !model?.length" class="required">*</span>
     </span>
     <span class="tbpro-textarea" :class="{ 'small-text': props.smallText }">
       <textarea

--- a/src/elements/TextInput.stories.ts
+++ b/src/elements/TextInput.stories.ts
@@ -38,6 +38,38 @@ export const Required: Story = {
     default: 'Favourite Food?',
     required: true,
   },
+  decorators: [
+    (story) => ({
+      components: { story },
+      template: `
+        <div>
+          <story />
+          <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+            <button @click="triggerInvalid">
+              Trigger Invalid State
+            </button>
+            <button @click="manualReset">
+              Manual Reset
+            </button>
+          </div>
+        </div>
+      `,
+      methods: {
+        triggerInvalid() {
+          const input = document.querySelector('input[name="fav-food"]') as HTMLInputElement;
+          const invalidEvent = new Event('invalid', { bubbles: true });
+          input.dispatchEvent(invalidEvent);
+        },
+        manualReset() {
+          const inputElement = document.querySelector('input[name="fav-food"]');
+
+          // Access the exposed methods through the Vue component's public interface
+          const componentExposed = (inputElement as any).__vueParentComponent?.exposed;
+          componentExposed.reset();
+        },
+      }
+    })
+  ]
 };
 
 export const RequiredWithPlaceholder: Story = {

--- a/src/elements/TextInput.vue
+++ b/src/elements/TextInput.vue
@@ -21,6 +21,17 @@ const focus = () => {
   inputRef.value.focus();
 };
 
+/**
+ * Resets the component's internal validation state and clears the input value.
+ * This should be explicitly called when the parent form is reset.
+ */
+const reset = () => {
+  model.value = "";
+  isInvalid.value = false;
+  isDirty.value = false;
+  validationMessage.value = "";
+};
+
 // component properties
 interface Props {
   name: string;
@@ -47,7 +58,7 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 defineEmits(["submit"]);
-defineExpose({ focus });
+defineExpose({ focus, reset });
 
 // Calculate padding left for the actual input considering prefix width and existing padding
 const inputPaddingLeft = computed(() =>

--- a/src/elements/TextInput.vue
+++ b/src/elements/TextInput.vue
@@ -84,7 +84,7 @@ const onChange = () => {
   <label class="wrapper" :for="name">
     <span class="label">
       <slot />
-      <span v-if="required && model?.length === 0" class="required">*</span>
+      <span v-if="required && !model?.length" class="required">*</span>
     </span>
     <span class="tbpro-input" :class="{ 'small-text': props.smallText }">
       <span v-if="prefix" ref="inputPrefix" class="tbpro-input-prefix">{{


### PR DESCRIPTION
## Description

- `TextInput` manages the `isDirty` internally that is never false after interaction. That would be fine except that when a form is reset, it would be nice to reset the `isDirty` as well so required fields can be consider "pristine" again. This PR now exposes a `reset()` function that should be called by the user of the component if they want to reset the inner values
  - The `reset()` function cleans internal state and the model value itself
  - Added manual reset and invalid buttons in the story for `Required` to showcase the behavior
- `TextInput` has a small bug where if it is required, it doesn't show the asterisk if there's no data entered yet as the conditional is not true (`model?.length === 0` would be `undefined === 0` as there is no model yet which is false)
- `TextArea` also has the same issue
- Bumps the version to v.0.6.11 as this is just a bug fix

Before (required but doesn't show the asterisk):
![image](https://github.com/user-attachments/assets/bbca42fa-06ee-4436-9a97-b20cb5210ad1)


After:
![Jul-03-2025 16-05-39](https://github.com/user-attachments/assets/21ea066a-d6af-4da2-bccc-42062a753082)


PS: The black border issue from the original ticket was actually an artifact of my gif recording software


Fixes:
https://github.com/thunderbird/services-ui/issues/52