### PR TITLE
Add option hinting for type and size props

### DIFF
--- a/src/elements/BaseBadge.vue
+++ b/src/elements/BaseBadge.vue
@@ -5,7 +5,7 @@ import StatusWarningIcon from '@/icons/StatusWarningIcon.vue';
 
 // component properties
 interface Props {
-  type?: string;
+  type?: 'primary' | 'secondary' | 'warning';
   icon?: boolean;
 }
 withDefaults(defineProps<Props>(), {

--- a/src/elements/BaseButton.vue
+++ b/src/elements/BaseButton.vue
@@ -4,8 +4,8 @@ import ToolTip from '@/elements/ToolTip.vue';
 
 // component properties
 interface Props {
-  type?: string;
-  size?: string;
+  type?: 'primary' | 'secondary' | 'link';
+  size?: 'regular' | 'small';
   tooltip?: string;
   forceTooltip?: boolean;
 };


### PR DESCRIPTION
This PR makes the string type for `type` and `size` props more precise by specifying the possible string options.

Fixes #14 