### PR TITLE
Explicitly emit the click event from the child component

### DIFF
--- a/src/elements/BaseButton.vue
+++ b/src/elements/BaseButton.vue
@@ -15,19 +15,29 @@ withDefaults(defineProps<Props>(), {
   tooltip: '',
   forceTooltip: false,
 })
-defineEmits(['click']);
+const emit = defineEmits(['click']);
 </script>
 
 <template>
-  <button class="tbpro-button" :class="{ [type]: type, 'small': size === 'small' }" type="button">
+  <button
+    class="tbpro-button"
+    :class="{ [type]: type, 'small': size === 'small' }"
+    type="button"
+    @click="emit('click')"
+  >
     <span class="icon" v-if="$slots?.icon">
       <slot name="icon"/>
     </span>
     <span class="text">
       <slot/>
     </span>
-    <tool-tip v-if="tooltip" class="tooltip" :class="{ 'display-tooltip': forceTooltip }"
-              :position="TooltipPosition.Bottom" @click.prevent>
+    <tool-tip
+      v-if="tooltip"
+      class="tooltip"
+      :class="{ 'display-tooltip': forceTooltip }"
+      :position="TooltipPosition.Bottom"
+      @click.prevent
+    >
       {{ tooltip }}
     </tool-tip>
   </button>

--- a/src/elements/BubbleSelect.vue
+++ b/src/elements/BubbleSelect.vue
@@ -14,7 +14,7 @@ withDefaults(defineProps<Props>(), {
 });
 
 const model = defineModel<number[]>({ default: [] });
-defineEmits(['click']);
+const emit = defineEmits(['click']);
 
 /**
  * Adds or removes the option value from the model.
@@ -38,6 +38,9 @@ const toggleBubble = (option: SelectOption) => {
 
   // Sort for niceness
   model.value.sort();
+
+  // Finally let the parent know there was a click
+  emit('click');
 };
 </script>
 


### PR DESCRIPTION
This PR fixes the click event on components not being emitted.

Fixes #28 