### PR TITLE
Add icon stories

### DIFF
--- a/src/icons/CopyIcon.stories.ts
+++ b/src/icons/CopyIcon.stories.ts
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import CopyIcon from "@/icons/CopyIcon.vue";
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories
+const meta: Meta<typeof CopyIcon> = {
+  title: 'Icons/Copy',
+  component: CopyIcon,
+  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Standard: Story = {
+  parameters: {
+    docs: {
+      source: { code: '<copy-icon />' },
+    },
+  }
+};

--- a/src/icons/NoticeIcon.stories.ts
+++ b/src/icons/NoticeIcon.stories.ts
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import NoticeInfoIcon from "@/icons/NoticeInfoIcon.vue";
+import NoticeSuccessIcon from "@/icons/NoticeSuccessIcon.vue";
+import NoticeWarningIcon from "@/icons/NoticeWarningIcon.vue";
+import NoticeCriticalIcon from "@/icons/NoticeCriticalIcon.vue";
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories
+const meta: Meta<typeof NoticeInfoIcon> = {
+  title: 'Icons/Notice',
+  component: NoticeInfoIcon,
+  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Info: Story = {
+  render: () => ({
+    components: { NoticeInfoIcon },
+    template: '<notice-info-icon />',
+  }),
+  parameters: {
+    docs: {
+      source: { code: '<notice-info-icon />' },
+    },
+  }
+};
+
+export const Success: Story = {
+  render: () => ({
+    components: { NoticeSuccessIcon },
+    template: '<notice-success-icon />',
+  }),
+  parameters: {
+    docs: {
+      source: { code: '<notice-success-icon />' },
+    },
+  }
+};
+
+export const Warning: Story = {
+  render: () => ({
+    components: { NoticeWarningIcon },
+    template: '<notice-warning-icon />',
+  }),
+  parameters: {
+    docs: {
+      source: { code: '<notice-warning-icon />' },
+    },
+  }
+};
+
+export const Critical: Story = {
+  render: () => ({
+    components: { NoticeCriticalIcon },
+    template: '<notice-critical-icon />',
+  }),
+  parameters: {
+    docs: {
+      source: { code: '<notice-critical-icon />' },
+    },
+  }
+};

--- a/src/icons/RefreshIcon.stories.ts
+++ b/src/icons/RefreshIcon.stories.ts
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import RefreshIcon from "@/icons/RefreshIcon.vue";
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories
+const meta: Meta<typeof RefreshIcon> = {
+  title: 'Icons/Refresh',
+  component: RefreshIcon,
+  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Standard: Story = {
+  parameters: {
+    docs: {
+      source: { code: '<refresh-icon />' },
+    },
+  }
+};

--- a/src/icons/StatusIcon.stories.ts
+++ b/src/icons/StatusIcon.stories.ts
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import StatusInfoIcon from "@/icons/StatusInfoIcon.vue";
+import StatusExpiryIcon from "@/icons/StatusExpiryIcon.vue";
+import StatusWarningIcon from "@/icons/StatusWarningIcon.vue";
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories
+const meta: Meta<typeof StatusInfoIcon> = {
+  title: 'Icons/Status',
+  component: StatusInfoIcon,
+  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Info: Story = {
+  render: () => ({
+    components: { StatusInfoIcon },
+    template: '<status-info-icon />',
+  }),
+  parameters: {
+    docs: {
+      source: { code: '<status-info-icon />' },
+    },
+  }
+};
+
+export const Expiry: Story = {
+  render: () => ({
+    components: { StatusExpiryIcon },
+    template: '<status-expiry-icon />',
+  }),
+  parameters: {
+    docs: {
+      source: { code: '<status-expiry-icon />' },
+    },
+  }
+};
+
+export const Warning: Story = {
+  render: () => ({
+    components: { StatusWarningIcon },
+    template: '<status-warning-icon />',
+  }),
+  parameters: {
+    docs: {
+      source: { code: '<status-warning-icon />' },
+    },
+  }
+};


### PR DESCRIPTION
This PR adds stories for all custom icon components this library holds at the moment. Notice and status icon stories were grouped together.

I couldn't find an easy way to auto-generate stories for components though. If we find a way in the future to do so, that would be nice. On the other hand, those are just a few custom icons we use a specific places (we're using open icon libs for all other places e.g. tabler icons in Appointment). But if we plan to provide a whole icon library ourselves, we can rethink this documentation.

Closes #62 