### PR TITLE
Add ToolTip stories

### DIFF
--- a/src/elements/ToolTip.stories.ts
+++ b/src/elements/ToolTip.stories.ts
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import { TooltipPosition } from '@/definitions';
+import ToolTip from '@/elements/ToolTip.vue';
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories
+const meta: Meta<typeof ToolTip> = {
+  title: 'Elements/ToolTip',
+  component: ToolTip,
+  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Standard: Story = {
+  args: {
+    default: 'Important note',
+  },
+};
+
+export const PositionTop: Story = {
+  args: {
+    default: 'Pointing upwards',
+    position: TooltipPosition.Top,
+  },
+};
+
+export const PositionLeft: Story = {
+  args: {
+    default: 'Pointing left',
+    position: TooltipPosition.Left,
+  },
+};
+
+export const PositionBottom: Story = {
+  args: {
+    default: 'Pointing downwards',
+    position: TooltipPosition.Bottom,
+  },
+};
+
+export const PositionRight: Story = {
+  args: {
+    default: 'Pointing right',
+    position: TooltipPosition.Right,
+  },
+};

--- a/src/elements/ToolTip.stories.ts
+++ b/src/elements/ToolTip.stories.ts
@@ -46,3 +46,10 @@ export const PositionRight: Story = {
     position: TooltipPosition.Right,
   },
 };
+
+export const PositionNone: Story = {
+  args: {
+    default: 'Pointing nowhere',
+    position: TooltipPosition.None,
+  },
+};


### PR DESCRIPTION
This PR adds documentation to the ToolTip component. Stories for availabile position values were added.

![image](https://github.com/user-attachments/assets/38ea3bd7-e314-4887-92c2-5d9a25d6ec4d)

Closes #65 
