### PR TITLE
Expose textarea `reset()` function to clear internal state

### DIFF
--- a/src/elements/TextArea.stories.ts
+++ b/src/elements/TextArea.stories.ts
@@ -43,9 +43,14 @@ export const Required: Story = {
       template: `
         <div>
           <story />
-          <button @click="triggerInvalid">
-            Force trigger invalid state
-          </button>
+          <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+            <button @click="triggerInvalid">
+              Force trigger invalid state
+            </button>
+            <button @click="manualReset">
+              Manual Reset
+            </button>
+          </div>
         </div>
       `,
       methods: {
@@ -55,7 +60,14 @@ export const Required: Story = {
             const invalidEvent = new Event('invalid', { bubbles: true });
             textarea.dispatchEvent(invalidEvent);
           }
-        }
+        },
+        manualReset() {
+          const inputElement = document.querySelector('textarea[name="fav-food"]');
+
+          // Access the exposed methods through the Vue component's public interface
+          const componentExposed = (inputElement as any).__vueParentComponent?.exposed;
+          componentExposed.reset();
+        },
       }
     })
   ]

--- a/src/elements/TextArea.vue
+++ b/src/elements/TextArea.vue
@@ -17,6 +17,16 @@ const focus = () => {
   textareaRef.value.focus();
 };
 
+/**
+ * Resets the component's internal validation state and clears the input value.
+ * This should be explicitly called when the parent form is reset.
+ */
+const reset = () => {
+  model.value = "";
+  isInvalid.value = false;
+  isDirty.value = false;
+};
+
 // component properties
 interface Props {
   name: string;
@@ -39,7 +49,8 @@ const props = withDefaults(defineProps<Props>(), {
   maxLength: null,
   dataTestid: 'text-area',
 });
-defineExpose({ focus });
+
+defineExpose({ focus, reset });
 
 const onInvalid = () => {
   isInvalid.value = true;


### PR DESCRIPTION
## Description of the change
Same problem as https://github.com/thunderbird/services-ui/issues/52, and same solution as https://github.com/thunderbird/services-ui/pull/54: the `textarea` holds a `isDirty` internal state which is not being cleared.

This change exposes a `.reset()` function that should be called to clear all internal state. This is useful for clearing out forms!


![Jul-21-2025 10-00-15](https://github.com/user-attachments/assets/45189f40-6c14-4bdd-8b65-475e594b7a72)



Solves https://github.com/thunderbird/services-ui/issues/72