### PR TITLE
Fix SelectInput width

### DIFF
--- a/src/elements/SelectInput.vue
+++ b/src/elements/SelectInput.vue
@@ -98,6 +98,7 @@ const onInvalid = (evt: HTMLInputElementEvent) => {
   font-size: var(--txt-input);
   font-weight: 400;
   padding: 0.75rem;
+  width: 100%;
 
   color: var(--txt-colour);
   


### PR DESCRIPTION
This PR fixes the SelectInput width and sets it to 100% of its container again. This was a regression from #82 where Tailwindcss classes got deleted, that were still being used.