### PR TITLE
Add a outerSuffix property to textinput (Fixes #87)

### DIFF
--- a/src/elements/TextInput.stories.ts
+++ b/src/elements/TextInput.stories.ts
@@ -125,6 +125,15 @@ export const OuterPrefix: Story = {
   },
 };
 
+export const OuterSuffix: Story = {
+  args: {
+    name: 'username',
+    default: 'Username',
+    placeholder: 'handle',
+    outerSuffix: '@example.org',
+  },
+};
+
 export const SmallText: Story = {
   args: {
     name: 'small-text',

--- a/src/elements/TextInput.vue
+++ b/src/elements/TextInput.vue
@@ -42,6 +42,7 @@ interface Props {
   placeholder?: string;
   prefix?: string; // A prefix shows up at the start of the input field and moves the actual input to the right.
   outerPrefix?: string; // A prefix shows up outside the input field and moves the whole input to the right.
+  outerSuffix?: string;
   required?: boolean;
   disabled?: boolean;
   smallText?: boolean;
@@ -120,6 +121,7 @@ const onChange = () => {
           ref="inputRef"
         />
       </span>
+      <span v-if="outerSuffix" class="tbpro-input-outer-suffix">{{ outerSuffix }}</span>
     </span>
     <span v-if="isInvalid" class="help-label invalid">
       {{ validationMessage }}
@@ -182,7 +184,8 @@ const onChange = () => {
   gap: 0.25rem;
   width: 100%;
 
-  .tbpro-input-outer-prefix {
+  .tbpro-input-outer-prefix,
+  .tbpro-input-outer-suffix {
     white-space: nowrap;
   }
 


### PR DESCRIPTION
This PR adds an outerSuffix property, it works like the outerPrefix but reversed.

<img width="608" height="375" alt="image" src="https://github.com/user-attachments/assets/86c69add-c8d3-4f90-a2f6-4472d6b46a64" />

Needed for keycloak's signup page. 