### PR TITLE
Allow for BubbleSelect to be singleSelection

### DIFF
--- a/src/elements/BubbleSelect.stories.ts
+++ b/src/elements/BubbleSelect.stories.ts
@@ -68,3 +68,8 @@ export const Disabled: Story = {
     required: false,
   },
 };
+export const SingleSelection: Story = {
+  args: {
+    singleSelection: true,
+  },
+};

--- a/src/elements/BubbleSelect.vue
+++ b/src/elements/BubbleSelect.vue
@@ -6,12 +6,14 @@ interface Props {
   options: SelectOption<string | number>[];
   required: boolean;
   disabled?: boolean;
+  singleSelection?: boolean;
   dataTestid?: string;
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
   required: false,
   disabled: false,
+  singleSelection: false,
   dataTestid: 'bubble-select',
 });
 
@@ -30,6 +32,9 @@ const toggleBubble = (option: SelectOption<string | number>) => {
   if (val > -1) {
     // We have the value, so filter it out
     model.value = model.value.filter((value) => option.value !== value);
+  } else if (props.singleSelection) {
+    // We don't have the value but we should only ever have one selection
+    model.value = [option.value]
   } else {
     // We don't have the value, so mix it in
     model.value = [...model.value, option.value];


### PR DESCRIPTION
This PR adds a `singleSelection` boolean prop that only ever selects a single value from the bubbles. The model is still an array for consistency with the "normal" usage.

Note that it is still possible to de-select and have an "empty" state so that this new prop still works well paired with `required` as shown in the GIF.

![Aug-13-2025 10-41-51](https://github.com/user-attachments/assets/f6714ac9-6e97-4a8b-9471-2fb6347014c5)

Related issues:
https://github.com/thunderbird/services-ui/issues/103
https://github.com/thunderbird/appointment/pull/1166