### PR TITLE
In CheckboxInput component, forward the onChange event object in emits

### DIFF
--- a/src/elements/CheckboxInput.stories.ts
+++ b/src/elements/CheckboxInput.stories.ts
@@ -39,6 +39,34 @@ export const Checked: Story = {
   },
 };
 
+export const OnChangeEvent: Story = {
+  args: {
+    name: 'on-change-event',
+    label: 'I agree to the terms and conditions.',
+  },
+  decorators: [
+    (story) => ({
+      components: { story },
+      data() {
+        return {
+          checkboxState: 'unchecked',
+        };
+      },
+      template: `
+        <div>
+          <story @change="handleChange" />
+          <p><strong>Current checkbox state:</strong> {{ checkboxState }}</p>
+        </div>
+      `,
+      methods: {
+        handleChange(event) {
+          this.checkboxState = event.target.checked ? 'checked' : 'unchecked';
+        },
+      },
+    }),
+  ],
+};
+
 export const Required: Story = {
   args: {
     name: 'required',

--- a/src/elements/CheckboxInput.vue
+++ b/src/elements/CheckboxInput.vue
@@ -70,9 +70,9 @@ const onInvalid = (evt: HTMLInputElementEvent) => {
  * this is so we can delay :invalid until
  * the user does something worth invalidating
  */
-const onChange = () => {
+const onChange = (event: Event) => {
   isDirty.value = true;
-  emit('change');
+  emit('change', event);
 };
 </script>
 


### PR DESCRIPTION
Fixing the following:

- A: Changed!
- B: Ok, what changed?
- A: undefined

Or "in CheckboxInput component, forward the onChange `event` object in the emitted event"

Added a story to showcase the behavior and making it easier to verify that it now works but happy to remove it once approved if wanted.

Related issues:
https://github.com/thunderbird/services-ui/issues/105