### PR TITLE
Make SwitchToggle focusable and togglable by space key

### DIFF
--- a/src/elements/SwitchToggle.vue
+++ b/src/elements/SwitchToggle.vue
@@ -56,7 +56,7 @@ const toggleState = () => {
     <div v-if="label">{{ label }}</div>
     <div class="toggle-container">
       <div v-if="!noLegend" class="toggle-label">{{ t('switchToggle.off') }}</div>
-      <div class="toggle">
+      <div class="toggle" tabindex="0" @keypress.space.prevent="toggleState">
         <input
           class="toggle-input"
           type="checkbox"

--- a/src/elements/SwitchToggle.vue
+++ b/src/elements/SwitchToggle.vue
@@ -56,7 +56,7 @@ const toggleState = () => {
     <div v-if="label">{{ label }}</div>
     <div class="toggle-container">
       <div v-if="!noLegend" class="toggle-label">{{ t('switchToggle.off') }}</div>
-      <div class="toggle" tabindex="0" @keypress.space.prevent="toggleState">
+      <div class="toggle" tabindex="0" @keyup.space.prevent="toggleState">
         <input
           class="toggle-input"
           type="checkbox"


### PR DESCRIPTION
This change adds the SwitchToggle component to the tabindex to make it accessible by keyboard. Also users can now trigger the toggle with the <kbd>space</kbd> key when focused.

> [!NOTE]
> This PR won't do any styling. The focus state style is left as is. 

Closes #102 