### PR TITLE
Fix i18n setup with Storybook's preview

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -10,7 +10,9 @@ const config: StorybookConfig = {
   ],
   framework: {
     name: '@storybook/vue3-vite',
-    options: {},
+    options: {
+      docgen: 'vue-component-meta',
+    },
   },
   core: {
     disableTelemetry: true,

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -2,6 +2,8 @@ import type { Preview } from '@storybook/vue3-vite';
 import '@/assets/styles/fonts.css';
 import '@/assets/styles/main.css';
 import { withThemeByClassName, withThemeByDataAttribute } from '@storybook/addon-themes';
+import { setup } from '@storybook/vue3-vite';
+import i18ninstance from '../src/composable/i18n';
 
 export const decorators = [
   withThemeByClassName({
@@ -36,5 +38,9 @@ const preview: Preview = {
     },
   },
 };
+
+setup((app) => {
+  app.use(i18ninstance);
+});
 
 export default preview;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,7 +3,7 @@ import '@/assets/styles/fonts.css';
 import '@/assets/styles/main.css';
 import { withThemeByClassName, withThemeByDataAttribute } from '@storybook/addon-themes';
 import { setup } from '@storybook/vue3-vite';
-import i18ninstance from '../src/composable/i18n';
+import i18ninstance from '@/composable/i18n';
 
 export const decorators = [
   withThemeByClassName({

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.json",
+}

--- a/src/patterns/StandardFooter.vue
+++ b/src/patterns/StandardFooter.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { computed } from 'vue';
 import { t } from '@/composable/i18n';
 import VisualDivider from '@/elements/VisualDivider.vue';
 
@@ -39,19 +38,6 @@ const urlMap = {
 } as const;
 
 const getUrl = (key: keyof typeof urlMap): string => urlMap[key];
-
-// Manually interpolating the copyright text as we can't use the i18n-t component
-const copyrightText = computed(() => {
-  const mzlaLinkHtml = `<a href="${getUrl('mzlaLink')}">${t('footer.mzlaLinkText')}</a>`;
-  const creativeCommonsLinkHtml = `<a href="${getUrl('creativeCommonsLink')}">${t('footer.creativeCommonsLinkText')}</a>`;
-  const currentYear = new Date().getFullYear();
-
-  return t('footer.copywrite', {
-    mzlaLink: mzlaLinkHtml,
-    currentYear: currentYear,
-    creativeCommonsLink: creativeCommonsLinkHtml
-  });
-});
 </script>
 
 <template>
@@ -84,7 +70,23 @@ const copyrightText = computed(() => {
           </li>
         </ul>
 
-        <p v-html="copyrightText"></p>
+        <p>
+          <i18n-t keypath="footer.copywrite" scope="global">
+            <template v-slot:mzlaLink>
+              <a :href="getUrl('mzlaLink')">
+                {{ $t('footer.mzlaLinkText') }}
+              </a>
+            </template>
+            <template v-slot:currentYear>
+              {{ new Date().getFullYear() }}
+            </template>
+            <template v-slot:creativeCommonsLink>
+              <a :href="getUrl('creativeCommonsLink')">
+                {{ $t('footer.creativeCommonsLinkText') }}
+              </a>
+            </template>
+          </i18n-t>
+        </p>
 
         <a class="underline" :href="props.contributeToThisSiteUrl" target="_blank">
           {{ t('footer.contributeToThisSite' )}}


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
In Storybook Preview, it wasn't possible to use the `i18n-t` component since there was no `vue-i18n` instance loaded when rendering a story. @MelissaAutumn found out that we should be doing a `setup` in preview to initialize it instead via https://storybook.js.org/docs/get-started/frameworks/vue3-vite?renderer=vue&ref=readme#extending-the-vue-application.

- Add `setup` function to initialize `i18n` (and other libs in the future, maybe)
- Update `StandardFooter` to use the `i18n-t` component for the copywrite text
- Add `vue-component-meta` to Storybook's `main.ts`
- Add a `tsconfig.json` inside the `.storybook` folder to relay the main `tsconfig.json` configuration so that we can use relative imports

## Benefits

<!-- What benefits will be realized by the code change? -->
We can use the `i18n-t` component for complex translations / inserts of components within translations in `services-ui`!

## Related tickets

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/services-ui/issues/137