### PR TITLE
Fix StandardFooter copywrite text

### DIFF
--- a/src/patterns/StandardFooter.vue
+++ b/src/patterns/StandardFooter.vue
@@ -71,7 +71,7 @@ const getUrl = (key: keyof typeof urlMap): string => urlMap[key];
         </ul>
 
         <p>
-          <i18n-t keypath="footer.copywrite" scope="global">
+          <i18n-t keypath="footer.copywrite">
             <template v-slot:mzlaLink>
               <a :href="getUrl('mzlaLink')">
                 {{ $t('footer.mzlaLinkText') }}


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
- From the docs, the [i18n scope resolution](https://vue-i18n.intlify.dev/guide/advanced/component#scope-resolving) should be the default instead of global if we want to define the keys within it in `services-ui` and not in each specific service. The default behaviour should suffice here as all the other keys work well except for this one.

## Benefits

- `footer.copywrite` text can be defined locally inside `services-ui` instead of relying on the global scope of the user's application to resolve it.

## Related tickets

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/services-ui/issues/145