### PR TITLE
Add xs size for user avatar

### DIFF
--- a/src/elements/UserAvatar.stories.ts
+++ b/src/elements/UserAvatar.stories.ts
@@ -46,6 +46,10 @@ export const Sizes: Story = {
       <div style="display:flex;gap:1rem;align-items:center;">
         <user-avatar
           username="Jennifer"
+          size="extra-small"
+        />
+        <user-avatar
+          username="Jennifer"
           size="small"
         />
         <user-avatar

--- a/src/elements/UserAvatar.vue
+++ b/src/elements/UserAvatar.vue
@@ -5,7 +5,7 @@ import { t } from '@/composable/i18n';
 interface Props {
   username: string,
   avatarUrl?: string,
-  size?: 'small' | 'regular' | 'large';
+  size?: 'extra-small' | 'small' | 'regular' | 'large';
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -49,6 +49,11 @@ const usernameInitial = computed(() => {
     font-style: normal;
     line-height: 1.43;
     color: var(--colour-ti-base-light);
+  }
+
+  &.extra-small {
+    width: 1.5rem;
+    height: 1.5rem;
   }
 
   &.small {


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change adds another value for the size property of the user-avatar component: `extra-small`

## Benefits

The component can now be better used in lists or contexts that require a really small size.

## Screenshots

<img width="307" height="195" alt="image" src="https://github.com/user-attachments/assets/24f7fc58-3760-428b-be90-67bb8ca8c0b5" />

## Known issues / things to improve

- Do we want to make that a breaking change and change the values to `xs`, `sm`, `md` and `lg` instead of the long word representations?

## Related tickets

Closes #149 
