### PR TITLE
Fix SegmentControl styles

### DIFF
--- a/src/elements/SegmentedControl.vue
+++ b/src/elements/SegmentedControl.vue
@@ -3,7 +3,6 @@ import { type SelectOption } from '@/models';
 
 interface Props {
   options: SelectOption<string | number>[];
-  legend: string;
   required: boolean;
   disabled?: boolean;
   dataTestid?: string;
@@ -31,7 +30,7 @@ const setOption = (option: SelectOption<string | number>) => {
 </script>
 
 <template>
-  <div class="wrapper">
+  <div class="segment-wrapper">
     <label>
       <span class="label">
         <slot />
@@ -60,10 +59,11 @@ const setOption = (option: SelectOption<string | number>) => {
 </template>
 
 <style scoped>
-.wrapper {
+.segment-wrapper {
   display: inline-flex;
   flex-direction: column;
-  color: var(--colour-ti-base);
+  gap: 0.5rem;
+  color: var(--colour-ti-secondary);
   font-family: 'Inter', 'sans-serif';
   font-size: var(--txt-input);
   line-height: var(--line-height-input);
@@ -76,10 +76,12 @@ const setOption = (option: SelectOption<string | number>) => {
 }
 .required {
   color: var(--colour-ti-critical);
+  padding-inline-start: 0.25rem;
 }
 
 .segment-list {
   padding: 0;
+  margin: 0;
   display: inline-flex;
   list-style: none;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,7 @@ import StatusInfoIcon from '@/icons/StatusInfoIcon.vue';
 import StatusWarningIcon from '@/icons/StatusWarningIcon.vue';
 
 // Types
-import { ExpiryUnitTypes, NoticeBarTypes } from '@/definitions';
+import { ExpiryUnitTypes, NoticeBarTypes, BaseBadgeTypes } from '@/definitions';
 
 // Patterns
 import StandardFooter from '@/patterns/StandardFooter.vue';
@@ -81,6 +81,7 @@ export {
   // Types
   ExpiryUnitTypes,
   NoticeBarTypes,
+  BaseBadgeTypes,
   // Patterns
   StandardFooter
 };


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
- Removed unused `legend` prop (label should be included as the default slot)
- Removed `margin` from the `ul` to make it easier to align in relation to other components
- Updated the color of the label, spacing between label and ul, and gap between label and "required asterisk"

## Benefits

<!-- What benefits will be realized by the code change? -->
- Matches the Design System
- Easier to align in relation to other components / in form contexts

## Screenshots

[Refer to the Design System Figma file](https://www.figma.com/design/1wGTkoIgRfyEbLeiW1XeIx/Design-System--%3E-Components?node-id=4025-403&m=dev)

<!-- Share visuals of the change if there are any -->
Before

<img width="533" height="85" alt="image" src="https://github.com/user-attachments/assets/0d98a0d9-f2ef-44b3-8763-260ea449872b" />


After

<img width="543" height="78" alt="image" src="https://github.com/user-attachments/assets/c6ecde12-c417-4a38-a7ef-34dc2f49fe03" />

--

Spacing before

<img width="530" height="107" alt="image" src="https://github.com/user-attachments/assets/33540b57-5385-4a13-b3bf-163146b99f21" />

Spacing after

<img width="531" height="81" alt="image" src="https://github.com/user-attachments/assets/c74068f7-bfcf-411b-a7f6-def0a7e79a69" />


## Related tickets

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/services-ui/issues/160