### PR TITLE
Update BubbleSelect styles

### DIFF
--- a/src/elements/BubbleSelect.stories.ts
+++ b/src/elements/BubbleSelect.stories.ts
@@ -1,4 +1,3 @@
-import { ref } from 'vue';
 import { fn } from 'storybook/test';
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
 
@@ -75,40 +74,9 @@ export const SingleSelection: Story = {
   },
 };
 export const WithHelp: Story = {
-  render: (args) => ({
-    components: { BubbleSelect },
-    setup() {
-      const error = ref<string | null>(null);
-
-      const setError = () => {
-        error.value = 'Please select at least one option.';
-      };
-
-      const resetError = () => {
-        error.value = null;
-      };
-
-      return {
-        ...args,
-        error,
-        setError,
-        resetError,
-        options: scheduleDayOptions,
-      };
-    },
-    template: `
-      <div>
-        <BubbleSelect name="with-vmodel" required :options="options" :error="error">Select Days</BubbleSelect>
-        <div style="display: inline-flex; gap: 0.5rem; margin-top: 0.5rem;">
-          <button type="button" @click="setError">
-            Trigger error
-          </button>
-
-          <button type="button" @click="resetError">
-            Reset error
-          </button>
-        </div>
-      </div>
-    `,
-  }),
+  args: {
+    default: 'Select Days',
+    required: true,
+    help: 'Select a desired day'
+  },
 };

--- a/src/elements/BubbleSelect.stories.ts
+++ b/src/elements/BubbleSelect.stories.ts
@@ -1,3 +1,4 @@
+import { ref } from 'vue';
 import { fn } from 'storybook/test';
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
 
@@ -6,31 +7,31 @@ import type { SelectOption } from '@/models';
 
 const scheduleDayOptions: SelectOption<string>[] = [
   {
-    label: 'S',
+    label: 'Sun',
     value: 'Sunday',
   },
   {
-    label: 'M',
+    label: 'Mon',
     value: 'Monday',
   },
   {
-    label: 'T',
+    label: 'Tue',
     value: 'Tuesday',
   },
   {
-    label: 'W',
+    label: 'Wed',
     value: 'Wednesday',
   },
   {
-    label: 'T',
+    label: 'Thu',
     value: 'Thursday',
   },
   {
-    label: 'F',
+    label: 'Fri',
     value: 'Friday',
   },
   {
-    label: 'S',
+    label: 'Sat',
     value: 'Saturday',
   },
 ];
@@ -72,4 +73,42 @@ export const SingleSelection: Story = {
   args: {
     singleSelection: true,
   },
+};
+export const WithHelp: Story = {
+  render: (args) => ({
+    components: { BubbleSelect },
+    setup() {
+      const error = ref<string | null>(null);
+
+      const setError = () => {
+        error.value = 'Please select at least one option.';
+      };
+
+      const resetError = () => {
+        error.value = null;
+      };
+
+      return {
+        ...args,
+        error,
+        setError,
+        resetError,
+        options: scheduleDayOptions,
+      };
+    },
+    template: `
+      <div>
+        <BubbleSelect name="with-vmodel" required :options="options" :error="error">Select Days</BubbleSelect>
+        <div style="display: inline-flex; gap: 0.5rem; margin-top: 0.5rem;">
+          <button type="button" @click="setError">
+            Trigger error
+          </button>
+
+          <button type="button" @click="resetError">
+            Reset error
+          </button>
+        </div>
+      </div>
+    `,
+  }),
 };

--- a/src/elements/BubbleSelect.stories.ts
+++ b/src/elements/BubbleSelect.stories.ts
@@ -73,6 +73,12 @@ export const SingleSelection: Story = {
     singleSelection: true,
   },
 };
+export const LargeGap: Story = {
+  args: {
+    default: 'Select Days',
+    bubbleGap: 'large',
+  },
+};
 export const WithHelp: Story = {
   args: {
     default: 'Select Days',

--- a/src/elements/BubbleSelect.vue
+++ b/src/elements/BubbleSelect.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { type SelectOption } from '@/models';
+import ErrorIcon from '@/icons/ErrorIcon.vue';
 
 // component properties
 interface Props {
   options: SelectOption<string | number>[];
   required: boolean;
+  help?: string;
+  error?: string;
   disabled?: boolean;
   singleSelection?: boolean;
   dataTestid?: string;
@@ -12,6 +15,8 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   required: false,
+  help: null,
+  error: null,
   disabled: false,
   singleSelection: false,
   dataTestid: 'bubble-select',
@@ -63,6 +68,7 @@ const toggleBubble = (option: SelectOption<string | number>) => {
           :aria-pressed="model.indexOf(option.value) > -1"
           :class="{
             selected: model.indexOf(option.value) > -1,
+            error,
             disabled,
           }"
           :title="option.fullLabel ?? String(option.value)"
@@ -74,6 +80,13 @@ const toggleBubble = (option: SelectOption<string | number>) => {
         </button>
       </li>
     </ul>
+    <span v-if="error" class="help-label invalid">
+      <error-icon />
+      {{ error }}
+    </span>
+    <span v-if="help" class="help-label">
+      {{ help }}
+    </span>
   </div>
 </template>
 
@@ -81,15 +94,17 @@ const toggleBubble = (option: SelectOption<string | number>) => {
 .wrapper {
   display: flex;
   flex-direction: column;
-  color: var(--colour-ti-base);
+  gap: 0.5rem;
+  color: var(--colour-ti-secondary);
   font-family: 'Inter', 'sans-serif';
-  font-size: var(--txt-input);
+  font-size: 1rem;
   line-height: var(--line-height-input);
   font-weight: 400;
 }
 
 .bubble-list {
   padding: 0;
+  margin: 0;
   display: flex;
   justify-content: space-between;
   list-style: none;
@@ -100,6 +115,26 @@ const toggleBubble = (option: SelectOption<string | number>) => {
   font-weight: 600;
 }
 
+.help-label {
+  display: flex;
+  align-items: center;
+  color: var(--colour-ti-muted);
+  box-sizing: border-box;
+
+  width: 100%;
+  font-size: 0.6875rem;
+  line-height: 0.9375rem;
+
+  &.invalid {
+    gap: 0.25rem;
+    border-radius: 0.25rem;
+    padding: 0.25rem;
+    font-size: 0.75rem;
+    background-color: var(--colour-danger-soft);
+    color: var(--colour-danger-default);
+  }
+}
+
 .tbpro-bubble {
   transition: var(--transition);
 
@@ -107,29 +142,40 @@ const toggleBubble = (option: SelectOption<string | number>) => {
   justify-content: center;
   align-items: center;
 
-  width: 2rem;
-  height: 2rem;
-  border: 0.0625rem solid var(--colour-neutral-border);
-  border-radius: 100%;
-  background-color: var(--colour-neutral-subtle);
-  font-weight: 700;
+  width: 2.75rem;
+  height: 2.75rem;
+  border: 0.0625rem solid rgba(0, 0, 0, 0.1);
+  border-radius: 6.25rem;
+  box-shadow: 2px 2px 4px 0 rgba(0, 0, 0, 0.05) inset;
+  background-color: var(--colour-neutral-lower);
+  font-weight: 600;
+  font-size: 0.8125rem;
   line-height: 150%;
-  color: var(--colour-ti-muted);
+  color: var(--colour-ti-secondary);
   cursor: pointer;
+  text-transform: uppercase;
+
+  &:hover:not(.selected) {
+    border-color: var(--colour-primary-hover);
+  }
 }
 
 .selected {
-  background-color: var(--colour-service-primary);
-  border-color: var(--colour-service-primary-pressed);
+  background-color: var(--colour-ti-secondary);
   color: var(--colour-neutral-base);
 }
 
 .required {
   color: var(--colour-ti-critical);
+  padding-inline-start: 0.25rem;
 }
 
 .disabled {
   cursor: default;
+}
+
+.error {
+  border-color: var(--colour-ti-critical);
 }
 
 .selected.disabled {

--- a/src/elements/BubbleSelect.vue
+++ b/src/elements/BubbleSelect.vue
@@ -8,6 +8,7 @@ import ErrorIcon from '@/icons/ErrorIcon.vue';
 interface Props {
   options: SelectOption<string | number>[];
   required: boolean;
+  bubbleGap?: 'default' | 'large';
   help?: string;
   error?: string;
   disabled?: boolean;
@@ -17,6 +18,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   required: false,
+  bubbleGap: 'default',
   help: null,
   error: null,
   disabled: false,
@@ -79,7 +81,7 @@ defineExpose({ reset });
         <span v-if="required && model?.length === 0" class="required">*</span>
       </span>
     </label>
-    <ul class="bubble-list">
+    <ul class="bubble-list" :class="`gap-${bubbleGap}`">
       <li v-for="option in options" :key="option.value">
         <button
           class="tbpro-bubble"
@@ -128,8 +130,15 @@ defineExpose({ reset });
   padding: 0;
   margin: 0;
   display: flex;
-  justify-content: space-between;
   list-style: none;
+
+  &.gap-default {
+    gap: 0.5rem;
+  }
+
+  &.gap-large {
+    gap: 1rem;
+  }
 }
 
 .label {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1,4 +1,7 @@
 {
+  "bubbleSelect": {
+    "error": "Bitte wählen Sie mindestens eine Option."
+  },
   "copyIcon": {
     "copyLink": "Link kopieren"
   },

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1,6 +1,6 @@
 {
   "bubbleSelect": {
-    "error": "Bitte wählen Sie mindestens eine Option."
+    "error": "Bitte mindestens eine Option wählen."
   },
   "copyIcon": {
     "copyLink": "Link kopieren"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,4 +1,7 @@
 {
+  "bubbleSelect": {
+    "error": "Please select at least one option."
+  },
   "copyIcon": {
     "copyLink": "Copy link"
   },


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
- Update `BubbleSelect` styles to match the [Design System in Figma](https://www.figma.com/design/1wGTkoIgRfyEbLeiW1XeIx/Design-System--%3E-Components?node-id=4023-375&m=dev).
- Added a `help` prop to be more aligned with other form fields / future-proofing.
- Added an error state based off of the other form-related components like `TextInput` / `SelectInput`.
  - There's a built-in error handling when the `BubbleSelect` is `required` and its model is `empty`. This one takes precedence.
  - Other errors can still be passed in as a normal string in the `error` prop.

## Benefits

<!-- What benefits will be realized by the code change? -->
- Better alignment with design team

## Screenshots

<!-- Share visuals of the change if there are any -->

https://github.com/user-attachments/assets/71e37b5c-a32e-4a41-800b-848e219194e2



## Known issues / things to improve

<!-- What things are intentionally left as is? -->
- This component is interesting. It may behave as a radio group (if `singleSelection` is `true`) or a group of checkboxes. It might be good to eventually rethink this whole functionality to make it more form-friendly. Currently, the implementation consists in a `ul` of `buttons` so we have to be a bit creative with `error` here:
  - I've added a built-in support for empty error if the `BubbleSelect` is `required`, which takes the priority over other errors.
  - The user of this component can still pass an arbitrary `error` string prop as well, if needed. 

## Related tickets

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/services-ui/issues/158