### PR TITLE
Add submit and reset form buttons

### DIFF
--- a/src/elements/BaseButton.stories.ts
+++ b/src/elements/BaseButton.stories.ts
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/vue3-vite';
 
 import BaseButton from '@/elements/BaseButton.vue';
 import RefreshIcon from '@/icons/RefreshIcon.vue';
+import TextInput from './TextInput.vue';
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories
 const meta: Meta<typeof BaseButton> = {
@@ -89,6 +90,44 @@ export const Link: Story = {
       source: { code: '<link-button>Click me!</link-button>' },
     },
   },
+};
+
+export const Submit: Story = {
+  args: {
+    type: 'primary',
+    formAction: 'submit',
+    default: 'Submit',
+  },
+  decorators: [
+    (story) => ({
+      components: { story, TextInput },
+      template: `
+        <form style="display:flex;gap:1rem;max-width:500px">
+          <text-input type="text" placeholder="Fill and submit me" />
+          <story />
+        </form>
+      `,
+    })
+  ]
+};
+
+export const Reset: Story = {
+  args: {
+    type: 'primary',
+    formAction: 'reset',
+    default: 'Reset',
+  },
+  decorators: [
+    (story) => ({
+      components: { story, TextInput },
+      template: `
+        <form style="display:flex;gap:1rem;max-width:500px">
+          <text-input type="text" placeholder="Fill and reset me" />
+          <story />
+        </form>
+      `,
+    })
+  ]
 };
 
 export const Small: Story = {

--- a/src/elements/BaseButton.vue
+++ b/src/elements/BaseButton.vue
@@ -9,6 +9,7 @@ interface Props {
   variant?: 'filled' | 'outline';
   tooltip?: string;
   forceTooltip?: boolean;
+  formAction?: 'none' | 'submit' | 'reset';
   dataTestid?: string;
   disabled?: boolean;
 }
@@ -18,6 +19,7 @@ withDefaults(defineProps<Props>(), {
   variant: 'filled',
   tooltip: '',
   forceTooltip: false,
+  formAction: 'none',
   dataTestid: 'button',
   disabled: false,
 });
@@ -27,7 +29,7 @@ withDefaults(defineProps<Props>(), {
   <button
     class="base"
     :class="{ [type]: type, small: size === 'small', [variant]: variant }"
-    type="button"
+    :type="formAction === 'none' ? 'button' : formAction"
     :data-testid="dataTestid"
     :disabled="disabled"
   >


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change introduces a new property `formAction` for the BaseButton that can have the following values:

- `none`: maps to `<button type="button">`
- `submit`: maps to `<button type="submit">`
- `reset`: maps to `<button type="reset">`

## Benefits

Our button components can now be used in classic forms too for the corresponding form action.

## Screenshots

<!-- Share visuals of the change if there are any -->
![services-ui-button-form-actions](https://github.com/user-attachments/assets/c1154a81-efdf-47ec-8d04-719b51112e99)

## Related tickets

Closes #91 
Closes #167 
