### PR TITLE
Add autofocus to form fields

### DIFF
--- a/src/elements/CheckboxInput.stories.ts
+++ b/src/elements/CheckboxInput.stories.ts
@@ -118,6 +118,14 @@ export const Required: Story = {
   ],
 };
 
+export const Autofocus: Story = {
+  args: {
+    name: 'autofocus-input',
+    label: 'Get Focus',
+    autofocus: true,
+  },
+};
+
 export const Help: Story = {
   args: {
     name: 'help',

--- a/src/elements/CheckboxInput.vue
+++ b/src/elements/CheckboxInput.vue
@@ -12,6 +12,7 @@ interface Props {
   error?: string;
   checked?: boolean;
   required?: boolean;
+  autofocus?: boolean;
   dataTestid?: string;
 }
 const props = withDefaults(defineProps<Props>(), {
@@ -20,6 +21,7 @@ const props = withDefaults(defineProps<Props>(), {
   error: null,
   checked: false,
   required: false,
+  autofocus: false,
   dataTestid: 'checkbox-input',
 });
 
@@ -97,6 +99,7 @@ defineOptions({
         :name="name"
         :checked="checked"
         :required="required"
+        :autofocus="autofocus"
         :data-testid="dataTestid"
         @invalid="onInvalid"
         @change="onChange"

--- a/src/elements/SelectInput.stories.ts
+++ b/src/elements/SelectInput.stories.ts
@@ -99,3 +99,16 @@ export const Required: Story = {
     }),
   ],
 };
+
+export const Autofocus: Story = {
+  args: {
+    name: 'autofocus-select',
+    default: 'Get Focus from',
+    options: [
+      { label: 'Aloy', value: 'aloy' },
+      { label: 'Rost', value: 'rost' },
+      { label: 'Sylens', value: 'sylens' },
+    ],
+    autofocus: true,
+  },
+};

--- a/src/elements/SelectInput.vue
+++ b/src/elements/SelectInput.vue
@@ -10,11 +10,13 @@ interface Props {
   options: SelectOption<number | string>[];
   help?: string;
   required?: boolean;
+  autofocus?: boolean;
   disabled?: boolean;
   dataTestid?: string;
 }
 withDefaults(defineProps<Props>(), {
   required: false,
+  autofocus: false,
   disabled: false,
   dataTestid: 'select-input',
 });
@@ -67,6 +69,7 @@ defineExpose({ reset });
         :id="name"
         :name="name"
         :required="required"
+        :autofocus="autofocus"
         :disabled="disabled"
         @invalid="onInvalid"
         @input="onInput"

--- a/src/elements/TextArea.stories.ts
+++ b/src/elements/TextArea.stories.ts
@@ -82,6 +82,15 @@ export const RequiredWithPlaceholder: Story = {
   },
 };
 
+export const Autofocus: Story = {
+  args: {
+    name: 'autofocus-input',
+    default: 'Give me my Focus',
+    placeholder: 'e.g. Aloy',
+    autofocus: true,
+  },
+};
+
 export const Help: Story = {
   args: {
     name: 'fav-beverage',

--- a/src/elements/TextArea.vue
+++ b/src/elements/TextArea.vue
@@ -33,6 +33,7 @@ interface Props {
   help?: string;
   placeholder?: string;
   required?: boolean;
+  autofocus?: boolean;
   disabled?: boolean;
   smallText?: boolean;
   maxLength?: number | string;
@@ -44,6 +45,7 @@ const props = withDefaults(defineProps<Props>(), {
   placeholder: null,
   prefix: null,
   required: false,
+  autofocus: false,
   disabled: false,
   smallText: false,
   maxLength: null,
@@ -82,6 +84,7 @@ const onChange = () => {
         :disabled="disabled"
         :placeholder="placeholder"
         :required="required"
+        :autofocus="autofocus"
         :maxLength="maxLength"
         :rows="rows"
         @invalid="onInvalid"

--- a/src/elements/TextInput.stories.ts
+++ b/src/elements/TextInput.stories.ts
@@ -128,6 +128,15 @@ export const RequiredWithOuterPrefix: Story = {
   ],
 };
 
+export const Autofocus: Story = {
+  args: {
+    name: 'autofocus-input',
+    default: 'Give me my Focus',
+    placeholder: 'e.g. Aloy',
+    autofocus: true,
+  },
+};
+
 export const Help: Story = {
   args: {
     name: 'help-input',

--- a/src/elements/TextInput.vue
+++ b/src/elements/TextInput.vue
@@ -45,6 +45,7 @@ interface Props {
   outerPrefix?: string; // A prefix shows up outside the input field and moves the whole input to the right.
   outerSuffix?: string;
   required?: boolean;
+  autofocus?: boolean;
   disabled?: boolean;
   smallText?: boolean;
   smallInput?: boolean;
@@ -58,6 +59,7 @@ const props = withDefaults(defineProps<Props>(), {
   placeholder: null,
   prefix: null,
   required: false,
+  autofocus: false,
   disabled: false,
   smallText: false,
   smallInput: false,
@@ -123,6 +125,7 @@ const onBlur = (evt) => {
           :disabled="disabled"
           :placeholder="placeholder"
           :required="required"
+          :autofocus="autofocus"
           :maxLength="maxLength"
           :style="{ paddingLeft: inputPaddingLeft }"
           :data-testid="dataTestid"


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This PR adds an `autofocus` property for the following input components:

- TextInput
- TextArea
- SelectInput
- CheckInput

## Benefits

Capability of setting auto focus to form fields.

## Known issues / things to improve

We have input elements, that don't use classic form elements (like e.g. BubbleSelect). I ignored those for now.

## Related tickets

Closes #90 
