### PR TITLE
Disable user selection for link buttons

### DIFF
--- a/src/elements/BaseButton.vue
+++ b/src/elements/BaseButton.vue
@@ -148,6 +148,9 @@ button:hover > .tooltip,
       -webkit-mask:
           linear-gradient(#000 0 0) content-box,
           linear-gradient(#000 0 0);
+      mask:
+          linear-gradient(#000 0 0) content-box,
+          linear-gradient(#000 0 0);
       -webkit-mask-composite: xor; /* Chrome/Safari/Edge */
       mask-composite: exclude; /* Firefox */
 
@@ -300,7 +303,7 @@ button:hover > .tooltip,
 
   .text {
     padding: 0;
-    user-select: all;
+    user-select: none;
     font-weight: 400;
     line-height: 1;
   }


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change disables user select for link button text too. Also a non-vendor-prefixed rule was added to fix a compatibility warning.

## Benefits

Prevention of unwanted text selection when double clicking a link button.

## Related tickets

closes #101