### PR TITLE
Add export member for IconButton component

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import BrandButton from '@/components/BrandButton.vue';
 import DangerButton from '@/components/DangerButton.vue';
 import LinkButton from '@/components/LinkButton.vue';
 import PrimaryButton from '@/components/PrimaryButton.vue';
+import IconButton from '@/components/IconButton.vue';
 
 // Inputs
 import BubbleSelect from '@/components/BubbleSelect.vue';
@@ -56,6 +57,7 @@ export {
   DangerButton,
   LinkButton,
   PrimaryButton,
+  IconButton,
   // Inputs
   BubbleSelect,
   CheckboxInput,


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change adds an export entry for the IconButton component that was missing.

## Benefits

Now IconButton can be imported in depending packages.

## Related tickets

Closes #205 
