### PR TITLE
Adjust password visibility icon to reflect current state

### DIFF
--- a/src/components/TextInput.vue
+++ b/src/components/TextInput.vue
@@ -135,10 +135,10 @@ const togglePasswordVisibility = () => {
           ref="inputRef"
         />
         <span v-if="passwordIsVisible === true" class="tbpro-input-suffix" @click="togglePasswordVisibility">
-          <eye-off-icon class="icon" />
+          <eye-icon class="icon" />
         </span>
         <span v-else-if="passwordIsVisible === false" class="tbpro-input-suffix" @click="togglePasswordVisibility">
-          <eye-icon class="icon" />
+          <eye-off-icon class="icon" />
         </span>
       </span>
       <span v-if="outerSuffix" class="tbpro-input-outer-suffix">{{ outerSuffix }}</span>


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change switches the password visibility icons to reflect the current state rather than the action it invokes.

## Benefits

UX consistency

## Screenshots

<img width="369" height="203" alt="image" src="https://github.com/user-attachments/assets/762ecc1b-600b-41a1-a788-3c8b67d984fc" />

## Known issues / things to improve

None

## Related tickets

Closes #209 
