### PR TITLE
Fix arrow to be clickable again

### DIFF
--- a/src/components/SelectInput.vue
+++ b/src/components/SelectInput.vue
@@ -6,7 +6,6 @@ import { ref } from 'vue';
 import { type SelectOption } from '@/models';
 import ErrorIcon from '@/foundation/ErrorIcon.vue';
 import CaretDownIcon from '@/foundation/CaretDownIcon.vue';
-import { InvalidEvent } from 'react';
 
 // component properties
 interface Props {


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change fixes the drop-down arrow to be clickable again.

## Benefits
Clicking the arrow now triggers the select to focus and show its drop-down.

## Screenshots

<img width="579" height="361" alt="image" src="https://github.com/user-attachments/assets/d95527f2-2313-4b8f-aed2-ae2198fe9a74" />

## Known issues / things to improve

None

## Related tickets

Closes #220 
