### PR TITLE
Update LoadingSkeleton props to be optional

### DIFF
--- a/src/components/LoadingSkeleton.vue
+++ b/src/components/LoadingSkeleton.vue
@@ -2,10 +2,10 @@
 import { t } from '@/composable/i18n';
 
 interface Props {
-  borderRadius: string;
-  width: string;
-  height: string;
-  isLoading: boolean;
+  borderRadius?: string;
+  width?: string;
+  height?: string;
+  isLoading?: boolean;
 }
 
 withDefaults(defineProps<Props>(), {


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change makes all properties of the LoadingSkeleton component optional. They already had default values set.

## Benefits

Improved DX

## Related tickets

Closes #179 
