### PR TITLE
Fix TextInput being marked dirty from focus

### DIFF
--- a/src/components/TextInput.stories.ts
+++ b/src/components/TextInput.stories.ts
@@ -56,6 +56,22 @@ export const Disabled: Story = {
   },
 };
 
+export const ReadOnly: Story = {
+  render: () => ({
+    components: { TextInput },
+    template: `
+      <text-input name="readonly-input" label="Preferred Name" modelValue="Frank, Son Of Frank" readonly />
+    `,
+  }),
+  parameters: {
+    docs: {
+      source: {
+        code: `<text-input name="disabled-input" label="Preferred Name" modelValue="Frank, Son Of Frank" readonly />`,
+      },
+    },
+  },
+};
+
 export const Required: Story = {
   decorators: [
     () => ({

--- a/src/components/TextInput.vue
+++ b/src/components/TextInput.vue
@@ -71,7 +71,6 @@ defineExpose({ focus, reset });
 
 const onInvalid = (evt: HTMLInputElementEvent) => {
   isInvalid.value = true;
-  isDirty.value = true;
   validationMessage.value = evt.target.validationMessage;
 };
 /**
@@ -80,16 +79,15 @@ const onInvalid = (evt: HTMLInputElementEvent) => {
  * the user does something worth invalidating
  */
 const onChange = () => {
-  inputRef.value.setCustomValidity('');
-  isInvalid.value = false;
   isDirty.value = true;
+  isInvalid.value = false;
   validationMessage.value = '';
+  inputRef.value.setCustomValidity('');
 };
 
 const onBlur = (evt) => {
-  if (evt.target.checkValidity()) {
+  if (isDirty.value && evt.target.checkValidity()) {
     isInvalid.value = false;
-    isDirty.value = true;
     validationMessage.value = '';
   }
 


### PR DESCRIPTION
Fixes #254 
Fixes #99 

We should only be marking a text input as dirty if we change something in it, and not when we simply focus and blur away. This fixes my main annoyance with our textinput :smile: 

Also I added a story for #99 and confirmed readonly works as intended. 