### PR TITLE
Fix the lack of tab/focus for password indicators, and add aria-live to it and maxLength.

### DIFF
--- a/src/components/TextArea.vue
+++ b/src/components/TextArea.vue
@@ -95,7 +95,7 @@ const onChange = () => {
         @invalid="onInvalid"
         @change="onChange"
       />
-      <span v-if="maxLength !== null" class="character-count"> {{ charCount }}/{{ maxLength }} </span>
+      <span v-if="maxLength !== null" class="character-count" aria-live="polite" :aria-label="$t('textInput.maxLengthAlt', {currentCount: charCount, maxCount: maxLength})"> {{ charCount }}/{{ maxLength }} </span>
     </span>
     <span v-if="isInvalid" class="help-label invalid">
       <error-icon />

--- a/src/components/TextArea.vue
+++ b/src/components/TextArea.vue
@@ -95,7 +95,7 @@ const onChange = () => {
         @invalid="onInvalid"
         @change="onChange"
       />
-      <span v-if="maxLength !== null" class="character-count" aria-live="polite" :aria-label="$t('textInput.maxLengthAlt', {currentCount: charCount, maxCount: maxLength})"> {{ charCount }}/{{ maxLength }} </span>
+      <span v-if="maxLength !== null" class="character-count" aria-live="polite" :aria-label="t('textInput.maxLengthAlt', {currentCount: charCount, maxCount: maxLength})"> {{ charCount }}/{{ maxLength }} </span>
     </span>
     <span v-if="isInvalid" class="help-label invalid">
       <error-icon />

--- a/src/components/TextInput.vue
+++ b/src/components/TextInput.vue
@@ -161,7 +161,7 @@ const charCount = computed(() => model.value?.length ?? 0);
           <eye-icon class="icon" alt="" v-if="passwordIsVisible === true" />
           <eye-off-icon class="icon" alt="" v-else-if="passwordIsVisible === false" />
         </span>
-        <span v-else-if="maxLength !== null" class="character-count tbpro-input-suffix" aria-live="polite" :aria-label="$t('textInput.maxLengthAlt', {currentCount: charCount, maxCount: maxLength})"> {{ charCount }}/{{ maxLength }}</span>
+        <span v-else-if="maxLength !== null" class="character-count tbpro-input-suffix" aria-live="polite" :aria-label="t('textInput.maxLengthAlt', {currentCount: charCount, maxCount: maxLength})"> {{ charCount }}/{{ maxLength }}</span>
       </span>
       <span v-if="outerSuffix" class="tbpro-input-outer-suffix">{{ outerSuffix }}</span>
     </span>

--- a/src/components/TextInput.vue
+++ b/src/components/TextInput.vue
@@ -5,8 +5,9 @@
 import { ref, computed, useAttrs, type InputTypeHTMLAttribute } from 'vue';
 import { type HTMLInputElementEvent } from '@/models';
 import ErrorIcon from '@/foundation/ErrorIcon.vue';
-import EyeIcon from '@/foundation/EyeIcon.vue';
 import EyeOffIcon from '@/foundation/EyeOffIcon.vue';
+import EyeIcon from '@/foundation/EyeIcon.vue';
+import { t } from '@/composable/i18n';
 
 const attrs = useAttrs();
 const model = defineModel<string>();
@@ -16,6 +17,9 @@ const isDirty = ref(false);
 const isRequired = Object.hasOwn(attrs, 'required');
 const inputRef = ref<HTMLInputElement>(null);
 const inputPrefix = ref<HTMLSpanElement>(null);
+const showPasswordText = t('textInput.passwordIndicator.show');
+const hidePasswordText = t('textInput.passwordIndicator.hide');
+const passwordIndicatorText = ref(showPasswordText);
 
 /**
  * Forwards focus intent to the text input element.
@@ -106,6 +110,11 @@ const passwordIsVisible = ref(isPasswordField ? false : null);
 const togglePasswordVisibility = () => {
   inputType.value = passwordIsVisible.value ? 'password' : 'text';
   passwordIsVisible.value = !passwordIsVisible.value;
+  if (passwordIsVisible.value === true) {
+    passwordIndicatorText.value = hidePasswordText;
+  } else if (passwordIsVisible.value === false) {
+    passwordIndicatorText.value = showPasswordText;
+  }
 };
 
 const charCount = computed(() => model.value?.length ?? 0);
@@ -140,13 +149,19 @@ const charCount = computed(() => model.value?.length ?? 0);
           @blur="onBlur"
           ref="inputRef"
         />
-        <span v-if="passwordIsVisible === true" class="tbpro-input-suffix" @click="togglePasswordVisibility">
-          <eye-icon class="icon" />
+        <span 
+          class="tbpro-input-suffix" 
+          aria-live="polite" 
+          tabindex="0" 
+          :title="passwordIndicatorText"
+          @keyup.space="togglePasswordVisibility" 
+          @click="togglePasswordVisibility"
+          v-if="passwordIsVisible !== null" 
+        >
+          <eye-icon class="icon" alt="" v-if="passwordIsVisible === true" />
+          <eye-off-icon class="icon" alt="" v-else-if="passwordIsVisible === false" />
         </span>
-        <span v-else-if="passwordIsVisible === false" class="tbpro-input-suffix" @click="togglePasswordVisibility">
-          <eye-off-icon class="icon" />
-        </span>
-        <span v-else-if="maxLength !== null" class="character-count tbpro-input-suffix"> {{ charCount }}/{{ maxLength }}</span>
+        <span v-else-if="maxLength !== null" class="character-count tbpro-input-suffix" aria-live="polite" :aria-label="$t('textInput.maxLengthAlt', {currentCount: charCount, maxCount: maxLength})"> {{ charCount }}/{{ maxLength }}</span>
       </span>
       <span v-if="outerSuffix" class="tbpro-input-outer-suffix">{{ outerSuffix }}</span>
     </span>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -64,6 +64,16 @@
   "textArea": {
     "invalidInput": "Ungültige Eingabe"
   },
+  "textInput": {
+    "passwordIndicator": {
+      "show": "Passwort anzeigen",
+      "hide": "Passwort ausblenden"
+    },
+    "maxLengthAlt": "{currentCount} von {maxCount} Zeichen verbleiben."
+  },
+  "userAvatar": {
+    "altText": "Avatar von {username}"
+  },
   "loadingSkeleton": {
     "loadingMessage": "Laden."
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -64,6 +64,13 @@
   "textArea": {
     "invalidInput": "Invalid input"
   },
+  "textInput": {
+    "passwordIndicator": {
+      "show": "Show password",
+      "hide": "Hide password"
+    },
+    "maxLengthAlt": "{currentCount} out of {maxCount} characters remaining."
+  },
   "userAvatar": {
     "altText": "{username}'s avatar."
   },


### PR DESCRIPTION
Fixes #250 

Will need some german l10n from @devmount here.  :sweat_smile: 

This makes password indicator tabbable which fixes the a11y issue. For a better time I added aria-polite and adjusted the v-ifs to avoid losing element focus when the indicator changes. 

I also added a custom aria label for maxLength which works quite well.