### PR TITLE
Fix TextArea and SelectInput being marked dirty from focus

### DIFF
--- a/src/components/SelectInput.stories.ts
+++ b/src/components/SelectInput.stories.ts
@@ -47,16 +47,22 @@ export const Standard: Story = {
 };
 
 export const Disabled: Story = {
-  args: {
-    name: 'disabled',
-    disabled: true,
+  render: () => ({
+    components: { SelectInput },
+    template: `
+      <select-input name="select-disabled" disabled />
+    `,
+  }),
+  parameters: {
+    docs: {
+      source: { code: '<select-input name="select-disabled" :options="[...]" disabled />' },
+    },
   },
 };
 
 export const Required: Story = {
   args: {
     name: 'required',
-    required: true,
     modelValue: '',
     help: 'Choose wisely.',
     options: [
@@ -74,7 +80,7 @@ export const Required: Story = {
     },
     template: `
       <div>
-        <select-input v-bind="args" ref="input" />
+        <select-input v-bind="args" ref="input" required />
         <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;margin-top: 0.5rem;">
           <button @click="triggerInvalid">
             Trigger Invalid State
@@ -104,6 +110,19 @@ export const Autofocus: Story = {
       { label: 'Rost', value: 'rost' },
       { label: 'Sylens', value: 'sylens' },
     ],
-    autofocus: true,
+  },
+  render: (args) => ({
+    components: { SelectInput },
+    setup() {
+      return { args };
+    },
+    template: `
+      <select-input v-bind="args" autofocus />
+    `,
+  }),
+  parameters: {
+    docs: {
+      source: { code: '<select-input name="select-autofocus" :options="[...]" disabled />' },
+    },
   },
 };

--- a/src/components/SelectInput.vue
+++ b/src/components/SelectInput.vue
@@ -2,10 +2,20 @@
 /**
  * @note The default slot is deprecated and will be removed in future releases
  */
-import { ref } from 'vue';
-import { type SelectOption } from '@/models';
+import { ref, useAttrs } from 'vue';
+import type { ElementEvent, SelectOption } from '@/models';
 import ErrorIcon from '@/foundation/ErrorIcon.vue';
 import CaretDownIcon from '@/foundation/CaretDownIcon.vue';
+
+const attrs = useAttrs();
+const model = defineModel<number | string>();
+const isInvalid = ref(false);
+const isDirty = ref(false);
+const isRequired = Object.hasOwn(attrs, 'required') && attrs.required !== false;
+const inputRef = ref<HTMLSelectElement>(null);
+const validationMessage = ref('');
+
+const emit = defineEmits(['submit', 'blur']);
 
 // component properties
 interface Props {
@@ -13,23 +23,26 @@ interface Props {
   label?: string;
   options: SelectOption<number | string>[];
   help?: string;
-  required?: boolean;
-  autofocus?: boolean;
-  disabled?: boolean;
+  error?: string;
   dataTestid?: string;
 }
 withDefaults(defineProps<Props>(), {
   label: null,
-  required: false,
-  autofocus: false,
-  disabled: false,
   dataTestid: 'select-input',
 });
 
-const model = defineModel<number | string>();
-const isInvalid = ref(false);
-const isDirty = ref(false);
-const validationMessage = ref('');
+defineOptions({ inheritAttrs: false });
+
+/**
+ * Forwards focus intent to the select element.
+ * Unlike HTMLElement.focus() this does not take any parameters.
+ */
+const focus = () => {
+  if (!inputRef.value) {
+    return;
+  }
+  inputRef.value.focus();
+};
 
 /**
  * Resets the component's internal validation state and clears the input value.
@@ -42,22 +55,27 @@ const reset = () => {
   validationMessage.value = '';
 };
 
-const onInvalid = (evt: Event) => {
+const onInvalid = (evt: ElementEvent<HTMLSelectElement>) => {
   isInvalid.value = true;
-  validationMessage.value = (evt.target as HTMLSelectElement).validationMessage;
+  validationMessage.value = evt.target.validationMessage;
 };
-const onInput = (evt: InputEvent) => {
+const onInput = () => {
   isDirty.value = true;
+  isInvalid.value = false;
+  validationMessage.value = '';
+  inputRef.value.setCustomValidity('');
+};
 
-  // Revalidate on input change
-  if ((evt.target as HTMLSelectElement).checkValidity()) {
+const onBlur = (evt: ElementEvent<HTMLSelectElement>) => {
+  if (isDirty.value && evt.target.checkValidity()) {
     isInvalid.value = false;
     validationMessage.value = '';
   }
+
+  emit('blur');
 };
 
-defineEmits(['submit']);
-defineExpose({ reset });
+defineExpose({ focus, reset });
 </script>
 
 <template>
@@ -65,21 +83,21 @@ defineExpose({ reset });
     <span v-if="label || $slots.default" class="label">
       <template v-if="label">{{ label }}</template>
       <slot v-else />
-      <span v-if="required && (model === null || model === '')" class="required">*</span>
+      <span v-if="isRequired && (model === null || model === '')" class="required">*</span>
     </span>
     <div class="tbpro-select-container">
       <select
-        class="tbpro-select"
-        :class="{ dirty: isDirty, invalid: isInvalid }"
+        v-bind="attrs"
         v-model="model"
+        class="tbpro-select"
+        :class="{ dirty: isDirty, error: error }"
         :id="name"
         :name="name"
-        :required="required"
-        :autofocus="autofocus"
-        :disabled="disabled"
         @invalid="onInvalid"
         @input="onInput"
+        @blur="onBlur"
         :data-testid="dataTestid"
+        ref="inputRef"
       >
         <option v-for="option in options" :value="option.value" :key="option.value">
           {{ option.label }}
@@ -180,7 +198,7 @@ defineExpose({ reset });
     color: var(--colour-ti-muted);
   }
 
-  &:hover {
+  &:hover:not(:disabled) {
     border-color: var(--colour-neutral-border-intense);
   }
 
@@ -198,7 +216,9 @@ defineExpose({ reset });
     cursor: not-allowed;
   }
 
-  &.invalid {
+  &.invalid,
+  &:has(.dirty:invalid):not(:focus-within),
+  &:has(.error):not(:focus-within) {
     border-color: var(--colour-ti-critical);
   }
 }

--- a/src/components/SelectInput.vue
+++ b/src/components/SelectInput.vue
@@ -109,6 +109,10 @@ defineExpose({ focus, reset });
       <error-icon />
       {{ validationMessage }}
     </span>
+    <span v-else-if="error" class="help-label invalid">
+      <error-icon />
+      {{ error }}
+    </span>
     <span v-if="help" class="help-label">
       {{ help }}
     </span>
@@ -217,8 +221,8 @@ defineExpose({ focus, reset });
   }
 
   &.invalid,
-  &:has(.dirty:invalid):not(:focus-within),
-  &:has(.error):not(:focus-within) {
+  &.dirty:invalid:not(:focus),
+  &.error:not(:focus) {
     border-color: var(--colour-ti-critical);
   }
 }

--- a/src/components/TextArea.stories.ts
+++ b/src/components/TextArea.stories.ts
@@ -46,6 +46,39 @@ export const Standard: Story = {
   },
 };
 
+export const Disabled: Story = {
+  render: () => ({
+    components: { TextArea },
+    template: `
+      <text-area name="disabled-input" label="Full Name" placeholder="e.g. John Doe" disabled />
+    `,
+  }),
+  parameters: {
+    docs: {
+      source: {
+        code: `<text-area name="disabled-input" label="Full Name" placeholder="e.g. John Doe" disabled />`,
+      },
+    },
+  },
+};
+
+
+export const ReadOnly: Story = {
+  render: () => ({
+    components: { TextArea },
+    template: `
+      <text-area name="readonly-input" label="Preferred Name" modelValue="Frank, Son Of Frank" readonly />
+    `,
+  }),
+  parameters: {
+    docs: {
+      source: {
+        code: `<text-area name="disabled-input" label="Preferred Name" modelValue="Frank, Son Of Frank" readonly />`,
+      },
+    },
+  },
+};
+
 export const Required: Story = {
   decorators: [
     () => ({

--- a/src/components/TextArea.vue
+++ b/src/components/TextArea.vue
@@ -4,20 +4,23 @@
  */
 import { computed, ref, useAttrs } from 'vue';
 import { t } from '@/composable/i18n';
-import ErrorIcon from '@/foundation/ErrorIcon.vue';
 import { useTextareaAutosize } from '@vueuse/core';
+import { HTMLTextareaElementEvent } from '@/models';
+import ErrorIcon from '@/foundation/ErrorIcon.vue';
 
-const isInvalid = ref(false);
-const isDirty = ref(false);
+const attrs = useAttrs();
 const model = defineModel<string>();
+const isInvalid = ref(false);
+const validationMessage = ref('');
+const isDirty = ref(false);
+const isRequired = Object.hasOwn(attrs, 'required');
+
 const { textarea } = useTextareaAutosize({
   input: model,
   styleProp: 'minHeight', // Provides support for the rows attribute
 });
 
 const charCount = computed(() => model.value?.length ?? 0);
-const attrs = useAttrs();
-const isRequired = Object.hasOwn(attrs, 'required');
 
 /**
  * Forwards focus intent to the text input element.
@@ -38,6 +41,7 @@ const reset = () => {
   model.value = '';
   isInvalid.value = false;
   isDirty.value = false;
+  validationMessage.value = '';
 };
 
 // component properties
@@ -45,6 +49,7 @@ interface Props {
   name: string;
   label?: string;
   help?: string;
+  error?: string;
   smallText?: boolean;
   maxLength?: number | string;
   dataTestid?: string;
@@ -52,18 +57,21 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   label: null,
   help: null,
+  error: null,
   prefix: null,
   smallText: false,
   maxLength: null,
   dataTestid: 'text-area',
 });
 
+const emit = defineEmits(['submit', 'blur']);
 defineExpose({ focus, reset });
 
-const onInvalid = () => {
+const onInvalid = (evt: HTMLTextareaElementEvent) => {
   isInvalid.value = true;
-  isDirty.value = true;
+  validationMessage.value = evt.target.validationMessage;
 };
+
 /**
  * On any change we mark the element as dirty
  * this is so we can delay :invalid until
@@ -71,6 +79,18 @@ const onInvalid = () => {
  */
 const onChange = () => {
   isDirty.value = true;
+  isInvalid.value = false;
+  validationMessage.value = '';
+  textarea.value.setCustomValidity('');
+};
+
+const onBlur = (evt: HTMLTextareaElementEvent) => {
+  if (isDirty.value && evt.target.checkValidity()) {
+    isInvalid.value = false;
+    validationMessage.value = '';
+  }
+
+  emit('blur');
 };
 </script>
 
@@ -83,25 +103,38 @@ const onChange = () => {
     </span>
     <span class="tbpro-textarea" :class="{ 'small-text': props.smallText }">
       <textarea
-        class="tbpro-textarea-element"
-        ref="textarea"
         v-bind="attrs"
         v-model="model"
-        :class="{ dirty: isDirty }"
+        class="tbpro-textarea-element"
+        :class="{
+          dirty: isDirty,
+          error: error !== null,
+        }"
         :id="name"
         :name="name"
-        :maxLength="maxLength"
+        :maxlength="maxLength"
         :data-testid="dataTestid"
         @invalid="onInvalid"
         @change="onChange"
+        @blur="onBlur"
+        ref="textarea"
       />
-      <span v-if="maxLength !== null" class="character-count" aria-live="polite" :aria-label="t('textInput.maxLengthAlt', {currentCount: charCount, maxCount: maxLength})"> {{ charCount }}/{{ maxLength }} </span>
+      <span
+        v-if="maxLength !== null"
+        class="character-count"
+        aria-live="polite"
+        :aria-label="t('textInput.maxLengthAlt', {currentCount: charCount, maxCount: maxLength})"
+      > {{ charCount }}/{{ maxLength }} </span>
     </span>
     <span v-if="isInvalid" class="help-label invalid">
       <error-icon />
-      {{ t('textArea.invalidInput') }}
+      {{ validationMessage }}
     </span>
-    <span v-else-if="help" class="help-label">
+    <span v-else-if="error" class="help-label invalid">
+      <error-icon />
+      {{ error }}
+    </span>
+    <span v-if="help" class="help-label">
       {{ help }}
     </span>
   </label>

--- a/src/components/TextArea.vue
+++ b/src/components/TextArea.vue
@@ -5,7 +5,7 @@
 import { computed, ref, useAttrs } from 'vue';
 import { t } from '@/composable/i18n';
 import { useTextareaAutosize } from '@vueuse/core';
-import { HTMLTextareaElementEvent } from '@/models';
+import type { ElementEvent } from '@/models';
 import ErrorIcon from '@/foundation/ErrorIcon.vue';
 
 const attrs = useAttrs();
@@ -67,7 +67,7 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits(['submit', 'blur']);
 defineExpose({ focus, reset });
 
-const onInvalid = (evt: HTMLTextareaElementEvent) => {
+const onInvalid = (evt: ElementEvent<HTMLTextAreaElement>) => {
   isInvalid.value = true;
   validationMessage.value = evt.target.validationMessage;
 };
@@ -84,7 +84,7 @@ const onChange = () => {
   textarea.value.setCustomValidity('');
 };
 
-const onBlur = (evt: HTMLTextareaElementEvent) => {
+const onBlur = (evt: ElementEvent<HTMLTextAreaElement>) => {
   if (isDirty.value && evt.target.checkValidity()) {
     isInvalid.value = false;
     validationMessage.value = '';

--- a/src/components/TextArea.vue
+++ b/src/components/TextArea.vue
@@ -208,7 +208,7 @@ const onBlur = (evt: ElementEvent<HTMLTextAreaElement>) => {
     border-radius: var(--border-radius);
     border: 0.0625rem solid var(--colour-neutral-border);
 
-    &:hover:enabled {
+    &:hover:enabled:not(:focus) {
       border-color: var(--colour-neutral-border-intense);
     }
 
@@ -221,7 +221,8 @@ const onBlur = (evt: ElementEvent<HTMLTextAreaElement>) => {
       outline: 0.0625rem solid var(--colour-primary-default);
     }
 
-    &.dirty:invalid {
+    &.dirty:invalid:not(:focus),
+    &.error:not(:focus) {
       border-color: var(--colour-ti-critical);
     }
 

--- a/src/components/TextInput.vue
+++ b/src/components/TextInput.vue
@@ -3,11 +3,11 @@
  * @note The default slot is deprecated and will be removed in future releases
  */
 import { ref, computed, useAttrs, type InputTypeHTMLAttribute } from 'vue';
-import { type HTMLInputElementEvent } from '@/models';
+import { type ElementEvent } from '@/models';
+import { t } from '@/composable/i18n';
 import ErrorIcon from '@/foundation/ErrorIcon.vue';
 import EyeOffIcon from '@/foundation/EyeOffIcon.vue';
 import EyeIcon from '@/foundation/EyeIcon.vue';
-import { t } from '@/composable/i18n';
 
 const attrs = useAttrs();
 const model = defineModel<string>();
@@ -74,7 +74,7 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits(['submit', 'blur']);
 defineExpose({ focus, reset });
 
-const onInvalid = (evt: HTMLInputElementEvent) => {
+const onInvalid = (evt: ElementEvent<HTMLInputElement>) => {
   isInvalid.value = true;
   validationMessage.value = evt.target.validationMessage;
 };
@@ -91,7 +91,7 @@ const onChange = () => {
   inputRef.value.setCustomValidity('');
 };
 
-const onBlur = (evt: HTMLInputElementEvent) => {
+const onBlur = (evt: ElementEvent<HTMLInputElement>) => {
   if (isDirty.value && evt.target.checkValidity()) {
     isInvalid.value = false;
     validationMessage.value = '';

--- a/src/components/TextInput.vue
+++ b/src/components/TextInput.vue
@@ -16,10 +16,11 @@ const validationMessage = ref('');
 const isDirty = ref(false);
 const isRequired = Object.hasOwn(attrs, 'required');
 const inputRef = ref<HTMLInputElement>(null);
-const inputPrefix = ref<HTMLSpanElement>(null);
 const showPasswordText = t('textInput.passwordIndicator.show');
 const hidePasswordText = t('textInput.passwordIndicator.hide');
 const passwordIndicatorText = ref(showPasswordText);
+
+const charCount = computed(() => model.value?.length ?? 0);
 
 /**
  * Forwards focus intent to the text input element.
@@ -77,6 +78,7 @@ const onInvalid = (evt: HTMLInputElementEvent) => {
   isInvalid.value = true;
   validationMessage.value = evt.target.validationMessage;
 };
+
 /**
  * On any change we mark the element as dirty
  * this is so we can delay :invalid until
@@ -89,7 +91,7 @@ const onChange = () => {
   inputRef.value.setCustomValidity('');
 };
 
-const onBlur = (evt) => {
+const onBlur = (evt: HTMLInputElementEvent) => {
   if (isDirty.value && evt.target.checkValidity()) {
     isInvalid.value = false;
     validationMessage.value = '';
@@ -114,8 +116,6 @@ const togglePasswordVisibility = () => {
     passwordIndicatorText.value = showPasswordText;
   }
 };
-
-const charCount = computed(() => model.value?.length ?? 0);
 </script>
 
 <template>
@@ -128,7 +128,7 @@ const charCount = computed(() => model.value?.length ?? 0);
     <span class="tbpro-input" :class="{ 'small-text': props.smallText }">
       <span v-if="outerPrefix" class="tbpro-input-outer-prefix">{{ outerPrefix }}</span>
       <span class="tbpro-input-wrapper" :class="{'small-input': props.smallInput}">
-        <span v-if="prefix" ref="inputPrefix" class="tbpro-input-prefix">{{ prefix }}</span>
+        <span v-if="prefix" class="tbpro-input-prefix">{{ prefix }}</span>
         <input
           v-bind="attrs"
           v-model="model"
@@ -140,7 +140,7 @@ const charCount = computed(() => model.value?.length ?? 0);
           :type="inputType"
           :id="name"
           :name="name"
-          :maxLength="maxLength"
+          :maxlength="maxLength"
           :data-testid="dataTestid"
           @invalid="onInvalid"
           @change="onChange"
@@ -159,7 +159,12 @@ const charCount = computed(() => model.value?.length ?? 0);
           <eye-icon class="icon" alt="" v-if="passwordIsVisible === true" />
           <eye-off-icon class="icon" alt="" v-else-if="passwordIsVisible === false" />
         </span>
-        <span v-else-if="maxLength !== null" class="character-count tbpro-input-suffix" aria-live="polite" :aria-label="t('textInput.maxLengthAlt', {currentCount: charCount, maxCount: maxLength})"> {{ charCount }}/{{ maxLength }}</span>
+        <span
+          v-else-if="maxLength !== null"
+          class="character-count tbpro-input-suffix"
+          aria-live="polite"
+          :aria-label="t('textInput.maxLengthAlt', {currentCount: charCount, maxCount: maxLength})"
+        > {{ charCount }}/{{ maxLength }}</span>
       </span>
       <span v-if="outerSuffix" class="tbpro-input-outer-suffix">{{ outerSuffix }}</span>
     </span>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -61,9 +61,6 @@
     "off": "Aus",
     "on": "An"
   },
-  "textArea": {
-    "invalidInput": "Ungültige Eingabe"
-  },
   "textInput": {
     "passwordIndicator": {
       "show": "Passwort anzeigen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -61,9 +61,6 @@
     "off": "Off",
     "on": "On"
   },
-  "textArea": {
-    "invalidInput": "Invalid input"
-  },
   "textInput": {
     "passwordIndicator": {
       "show": "Show password",

--- a/src/models.ts
+++ b/src/models.ts
@@ -26,15 +26,7 @@ export type Coloring = {
   background?: string;
 };
 
-export type HTMLElementEvent = Event & {
-  target: HTMLElement;
-  currentTarget: HTMLElement;
-};
-export type HTMLInputElementEvent = Event & {
-  target: HTMLInputElement;
-  currentTarget: HTMLInputElement;
-};
-export type HTMLTextareaElementEvent = Event & {
-  target: HTMLTextAreaElement;
-  currentTarget: HTMLTextAreaElement;
+export type ElementEvent<T> = Event & {
+  target: T;
+  currentTarget: T;
 };

--- a/src/models.ts
+++ b/src/models.ts
@@ -34,3 +34,7 @@ export type HTMLInputElementEvent = Event & {
   target: HTMLInputElement;
   currentTarget: HTMLInputElement;
 };
+export type HTMLTextareaElementEvent = Event & {
+  target: HTMLTextAreaElement;
+  currentTarget: HTMLTextAreaElement;
+};

--- a/test/components/SelectInput.test.js
+++ b/test/components/SelectInput.test.js
@@ -33,56 +33,23 @@ describe('SelectInput', () => {
     { 
       options: options,
       defaultSelected: options[2]['value'],
+      error: null,
       helpText: null,
-      required: false,
-      autoFocus: false,
-      disabled: false,
       dataTestid: 'standard-select-input',
     },
     { 
       options: options,
       defaultSelected: null,
+      error: null,
       helpText: null,
-      required: false,
-      autoFocus: false,
-      disabled: false,
       dataTestid: 'select-input-no-default',
     },
     { 
       options: options,
       defaultSelected: options[0]['value'],
+      error: null,
       helpText: 'This is the help text!',
-      required: false,
-      autoFocus: false,
-      disabled: false,
       dataTestid: 'select-input-help-text',
-    },
-    { 
-      options: options,
-      defaultSelected: null,
-      helpText: null,
-      required: true,
-      autoFocus: false,
-      disabled: false,
-      dataTestid: 'select-input-required',
-    },
-    { 
-      options: options,
-      defaultSelected: options[0]['value'],
-      helpText: null,
-      required: false,
-      autoFocus: true,
-      disabled: false,
-      dataTestid: 'select-input-autofocus',
-    },
-    { 
-      options: options,
-      defaultSelected: options[0]['value'],
-      helpText: null,
-      required: false,
-      autoFocus: false,
-      disabled: true,
-      dataTestid: 'select-input-disabled',
     },
   ];
 
@@ -91,16 +58,14 @@ describe('SelectInput', () => {
   });
 
   it.each(testCases)('renders correctly with the given options',
-    async ({ options, defaultSelected, helpText, required, autoFocus, disabled, dataTestid }) => {
+    async ({ options, defaultSelected, error, helpText, dataTestid }) => {
     const ourProps = {
       name: 'standard',
       label: 'Will your favourite MLB team win the world series this year?',
       options: options,
       modelValue: defaultSelected,
+      error: error,
       help: helpText,
-      required: required,
-      autofocus: autoFocus,
-      disabled: disabled,
       dataTestid: dataTestid,
     };
 

--- a/test/components/SelectInput.test.js
+++ b/test/components/SelectInput.test.js
@@ -51,6 +51,13 @@ describe('SelectInput', () => {
       helpText: 'This is the help text!',
       dataTestid: 'select-input-help-text',
     },
+    { 
+      options: options,
+      defaultSelected: null,
+      error: 'This is the error text!',
+      helpText: null,
+      dataTestid: 'select-input-no-default',
+    },
   ];
 
   afterEach(() => {
@@ -82,6 +89,12 @@ describe('SelectInput', () => {
     expect(selInput.isVisible()).toBe(true);
     expect(selInput.attributes().name).toBe(ourProps['name']);
 
+    let expClass = 'tbpro-select';
+    if (ourProps['error']) {
+      expClass += ' error';
+    }
+    expect(selInput.attributes().class).toBe(expClass);
+
     const selInputLabel = wrapper.find('.label');
     expect(selInputLabel.exists()).toBe(true);
     expect(selInputLabel.isVisible()).toBe(true);
@@ -91,6 +104,14 @@ describe('SelectInput', () => {
     if (ourProps['required'] == true && !ourProps['modelValue']) {
       expect(selInputLabel.text()).toContain('*');
     }
+
+    // verify error text is there if was provided  
+    if (ourProps['error']) {  
+      const selectInputError = wrapper.find('span.help-label.invalid');  
+      expect(selectInputError.exists()).toBe(true);  
+      expect(selectInputError.isVisible()).toBe(true);  
+      expect(selectInputError.text()).toBe(ourProps['error']);  
+    }  
 
     // if help text set, ensure it is displayed
     if (ourProps['help']) {

--- a/test/components/TextArea.test.js
+++ b/test/components/TextArea.test.js
@@ -10,6 +10,7 @@ describe('TextArea', () => {
   const testCases = [
     { 
       label: 'This is the TextArea label!',
+      error: null,
       help: null,
       smallText: false,
       maxLength: null,
@@ -18,6 +19,7 @@ describe('TextArea', () => {
     },
     { 
       label: 'This is the TextArea label!',
+      error: null,
       help: 'Please type in some text',
       smallText: false,
       maxLength: null,
@@ -26,6 +28,7 @@ describe('TextArea', () => {
     },
     { 
       label: 'This is the TextArea label!',
+      error: null,
       help: null,
       smallText: true,
       maxLength: null,
@@ -34,6 +37,7 @@ describe('TextArea', () => {
     },
     { 
       label: 'This is the TextArea label!',
+      error: null,
       help: null,
       smallText: false,
       maxLength: 25,
@@ -42,6 +46,7 @@ describe('TextArea', () => {
     },
     { 
       label: 'This is the TextArea label!',
+      error: null,
       help: null,
       smallText: false,
       maxLength: null,
@@ -50,6 +55,7 @@ describe('TextArea', () => {
     },
     { 
       label: 'This is the TextArea label!',
+      error: null,
       help: null,
       smallText: false,
       maxLength: 25,
@@ -58,6 +64,7 @@ describe('TextArea', () => {
     },    
     { 
       label: 'This is the TextArea label!',
+      error: null,
       help: null,
       smallText: false,
       maxLength: null,
@@ -66,6 +73,7 @@ describe('TextArea', () => {
     },
     { 
       label: 'This is the TextArea label!',
+      error: null,
       help: null,
       smallText: false,
       maxLength: null,
@@ -79,10 +87,11 @@ describe('TextArea', () => {
   });
 
   it.each(testCases)('renders correctly with the given options',
-    async ({ label, help, smallText, maxLength, modelValue, dataTestid}) => {
+    async ({ label, error, help, smallText, maxLength, modelValue, dataTestid}) => {
     const ourProps = {
       name: 'text-area-test',
       label: label,
+      error: error,
       help: help,
       smallText: smallText,
       maxLength: maxLength,

--- a/test/components/TextArea.test.js
+++ b/test/components/TextArea.test.js
@@ -80,6 +80,15 @@ describe('TextArea', () => {
       modelValue: 'This is the default text',
       dataTestid: 'standard-text-area-required',
     },
+    { 
+      label: 'This is the TextArea label!',
+      error: 'This is the error text!',
+      help: null,
+      smallText: false,
+      maxLength: null,
+      modelValue: 'This is the default text',
+      dataTestid: 'standard-text-area-error',
+    },
   ];
 
   afterEach(() => {
@@ -111,7 +120,11 @@ describe('TextArea', () => {
     expect(textArea.exists()).toBe(true);
     expect(textArea.isVisible()).toBe(true);
 
-    expect(textArea.attributes().class).toBe('tbpro-textarea-element');
+    let expClass = 'tbpro-textarea-element';
+    if (ourProps['error']) {
+      expClass += ' error';
+    }
+    expect(textArea.attributes().class).toBe(expClass);
     expect(textArea.attributes().name).toBe(ourProps['name']);
     expect(textArea.attributes().id).toBe(ourProps['name']);
 
@@ -119,6 +132,14 @@ describe('TextArea', () => {
     expect(textAreaLbl.exists()).toBe(true);
     expect(textAreaLbl.isVisible()).toBe(true);
     expect(textAreaLbl.text()).toBe(ourProps['label']);
+
+    // verify error text is there if was provided  
+    if (ourProps['error']) {  
+      const textAreaError = wrapper.find('span.help-label.invalid');  
+      expect(textAreaError.exists()).toBe(true);  
+      expect(textAreaError.isVisible()).toBe(true);  
+      expect(textAreaError.text()).toBe(ourProps['error']);  
+    }  
 
     // verify help text is there if was provided
     if (ourProps['help']) {


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change aligns the implementation of our `TextArea` and `SelectInput` components with the one of `TextInput`, taking the latter as template regarding structure, events and behavior - including the dirty state on blur.

Additionally the following improvements were made:

- The `TextArea` stories were extended for readonly and disabled states.
- The `TextArea` component now shows custom form validation messages and has a `onBlur()` method now.
- Unused l10n snippets and a const in TextInput were removed
- The auto generated demo code displayed for `SelectInput` stories was replace by a manual code to display the important attributes better
- The `SelectInput` component now binds all attributes to the actual select element.
- The `SelectInput` component now has a `focus()` method
- The the disabled `SelectInput` won't have a hover effect any longer.
- Tests were modified to reflect the changes

## Benefits

Cleaner and more consistent code. No annoying premature error messages.

## Related tickets

Closes #207 ~(Not closing since there are more input components to check first)~
