### PR TITLE
Fix code examples for ToolTip component

### DIFF
--- a/src/components/ToolTip.stories.ts
+++ b/src/components/ToolTip.stories.ts
@@ -8,84 +8,50 @@ const meta: Meta<typeof ToolTip> = {
   component: ToolTip,
   // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
+  argTypes: {
+    position: { control: 'select', options: Object.values(TooltipPosition) },
+    default: { control: 'text' },
+  },
+  args: {
+    default: 'Primary',
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Standard: Story = {
-  args: {
-    default: 'Important note',
-  },
   decorators: [
     (story) => ({
       components: { story },
       template: `<div style="min-height:60px;"><story /></div>`,
     }),
   ],
+  parameters: {
+    docs: {
+      source: {
+        code: '<tool-tip>Primary</tool-tip>',
+      },
+    },
+  },
 };
 
-export const PositionTop: Story = {
-  args: {
-    default: 'Pointing upwards',
-    position: TooltipPosition.Top,
+export const Position: Story = {
+  render: () => ({
+    components: { ToolTip },
+    template: `<div style="display:flex;flex-direction:column;gap:1rem;">
+      <div style="position:relative;height:3rem;"><tool-tip position="pos-top">Pointing upwards</tool-tip></div>
+      <div style="position:relative;height:3rem;"><tool-tip position="pos-left">Pointing left</tool-tip></div>
+      <div style="position:relative;height:3rem;"><tool-tip position="pos-bottom">Pointing downwards</tool-tip></div>
+      <div style="position:relative;height:3rem;"><tool-tip position="pos-right">Pointing right</tool-tip></div>
+      <div style="position:relative;height:3rem;"><tool-tip position="pos-none">Pointing nowhere</tool-tip></div>
+    </div>`,
+  }),
+  parameters: {
+    docs: {
+      source: {
+        code: '<tool-tip position="pos-top">Pointing upwards</tool-tip>\n<tool-tip position="pos-left">Pointing left</tool-tip>\n<tool-tip position="pos-bottom">Pointing downwards</tool-tip>\n<tool-tip position="pos-right">Pointing right</tool-tip>\n<tool-tip position="pos-none">Pointing nowhere</tool-tip>',
+      },
+    },
   },
-  decorators: [
-    (story) => ({
-      components: { story },
-      template: `<div style="min-height:60px;"><story /></div>`,
-    }),
-  ],
-};
-
-export const PositionLeft: Story = {
-  args: {
-    default: 'Pointing left',
-    position: TooltipPosition.Left,
-  },
-  decorators: [
-    (story) => ({
-      components: { story },
-      template: `<div style="min-height:60px;"><story /></div>`,
-    }),
-  ],
-};
-
-export const PositionBottom: Story = {
-  args: {
-    default: 'Pointing downwards',
-    position: TooltipPosition.Bottom,
-  },
-  decorators: [
-    (story) => ({
-      components: { story },
-      template: `<div style="min-height:60px;"><story /></div>`,
-    }),
-  ],
-};
-
-export const PositionRight: Story = {
-  args: {
-    default: 'Pointing right',
-    position: TooltipPosition.Right,
-  },
-  decorators: [
-    (story) => ({
-      components: { story },
-      template: `<div style="min-height:60px;"><story /></div>`,
-    }),
-  ],
-};
-
-export const PositionNone: Story = {
-  args: {
-    default: 'Pointing nowhere',
-    position: TooltipPosition.None,
-  },
-  decorators: [
-    (story) => ({
-      components: { story },
-      template: `<div style="min-height:60px;"><story /></div>`,
-    }),
-  ],
 };

--- a/src/components/ToolTip.stories.ts
+++ b/src/components/ToolTip.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import { TooltipPosition } from '@/definitions';
 import ToolTip from '@/components/ToolTip.vue';
+import PrimaryButton from './PrimaryButton.vue';
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories
 const meta: Meta<typeof ToolTip> = {
@@ -51,6 +52,28 @@ export const Position: Story = {
     docs: {
       source: {
         code: '<tool-tip position="pos-top">Pointing upwards</tool-tip>\n<tool-tip position="pos-left">Pointing left</tool-tip>\n<tool-tip position="pos-bottom">Pointing downwards</tool-tip>\n<tool-tip position="pos-right">Pointing right</tool-tip>\n<tool-tip position="pos-none">Pointing nowhere</tool-tip>',
+      },
+    },
+  },
+};
+
+export const Context: Story = {
+  render: () => ({
+    components: { ToolTip, PrimaryButton },
+    template: `<div style="position:relative; padding-top:3rem;">
+      <primary-button>
+        Copy the booking link
+      </primary-button>
+      <tool-tip style="top:0;">
+        This button copies to clipboard
+      </tool-tip>
+      <p>Tooltips are currently not assigned to a specific element, but placed and positioned separately. This will be improved in the future.</p>
+    </div>`,
+  }),
+  parameters: {
+    docs: {
+      source: {
+        code: '<div style="position: relative; padding-top: 3rem;">\n  <primary-button>\n    Copy the booking link\n  </primary-button>\n  <tool-tip style="top: 0;">\n    This button copies to clipboard\n  </tool-tip>\n</div>',
       },
     },
   },


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->
This change improves the demo code examples and enhances the stories for the `ToolTip` component. Stories are now grouped by slot or property. Component names and HTML attributes are now in dash-case. Reactivity for the default story is kept intact.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->
More organized and consistent documentation.

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->
None.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->
Closes #268 

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

This reorganizes stories from this:

<img width="20%" alt="image" src="https://github.com/user-attachments/assets/2054d440-3c85-4f9e-ac5d-85eb8d817ac4" />

to this:

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/48e1353b-7cf9-4613-9347-f29e9095c1bf" />

