### PR TITLE
Fix code examples for NoticeBar component

### DIFF
--- a/src/components/NoticeBar.stories.ts
+++ b/src/components/NoticeBar.stories.ts
@@ -11,65 +11,71 @@ const meta: Meta<typeof NoticeBar> = {
   component: NoticeBar,
   // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
+  argTypes: {
+    type: { control: 'select', options: Object.values(NoticeBarTypes) },
+    default: { control: 'text' },
+  },
   args: {
     default: 'Hello World!',
+    type: NoticeBarTypes.Info,
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Info: Story = {
+export const Standard: Story = {
   args: {
     default: 'You have 10,000 new emails.',
-    type: NoticeBarTypes.Info,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: '<notice-bar>You have 10,000 new emails.</notice-bar>',
+      },
+    },
   },
 };
 
-export const InfoWithCTA: Story = {
-  args: {
-    default: 'You have 10,000 new emails.',
-    type: NoticeBarTypes.Info,
-  },
-  render: (args) => ({
+export const CTAControls: Story = {
+  render: () => ({
     components: { NoticeBar, PrimaryButton, LinkButton },
-    setup() {
-      return { args };
-    },
     template: `
-      <NoticeBar>
-        {{ args.default }}
+      <notice-bar>
+        This form is dirty.
 
         <template #cta>
-          <button
-            style="border:none;background-color:inherit;color: var(--colour-ti-secondary);text-decoration:underline;cursor:pointer;"
-          >
-            Revert changes
-          </button>
-          <PrimaryButton size="small">Save changes</PrimaryButton>
+          <link-button>Revert changes</link-button>
+          <primary-button size="small">Save changes</primary-button>
         </template>
-      </NoticeBar>
+      </notice-bar>
     `,
   }),
-};
-
-export const Success: Story = {
-  args: {
-    default: 'You have 10,000 new emails.',
-    type: NoticeBarTypes.Success,
+  parameters: {
+    docs: {
+      source: {
+        code: '<notice-bar>\n  This form is dirty.\n\n  <template #cta>\n    <link-button>Revert changes</link-button>\n    <primary-button size="small">Save changes</primary-button>\n  </template>\n</notice-bar>',
+      },
+    },
   },
 };
 
-export const Warning: Story = {
-  args: {
-    default: 'You have 10,000 new emails.',
-    type: NoticeBarTypes.Warning,
-  },
-};
-
-export const Critical: Story = {
-  args: {
-    default: 'You have 10,000 new emails.',
-    type: NoticeBarTypes.Critical,
+export const Type: Story = {
+  render: () => ({
+    components: { NoticeBar, PrimaryButton, LinkButton },
+    template: `<div style="display:flex;flex-direction:column;gap:1rem">
+        <notice-bar type="info">You have unread emails.</notice-bar>
+        <notice-bar type="success">You have no new emails.</notice-bar>
+        <notice-bar type="warning">You have 10 new emails.</notice-bar>
+        <notice-bar type="critical">You have 10,000 new emails.</notice-bar>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      source: {
+        code: '<notice-bar type="info">You have unread emails.</notice-bar>\n<notice-bar type="success">You have no new emails.</notice-bar>\n<notice-bar type="warning">You have 10 new emails.</notice-bar>\n<notice-bar type="critical">You have 10,000 new emails.</notice-bar>',
+      },
+    },
   },
 };


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->
This change improves the demo code examples and enhances the stories for the `NoticeBar` component. Stories are now grouped by slot or property. Component names and HTML attributes are now in dash-case. Reactivity for the default story is kept intact.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->
More organized and consistent documentation.

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->
None.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->
Closes #264 

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

This reorganizes stories from this:

<img width="30%" alt="image" src="https://github.com/user-attachments/assets/563f8890-4ae4-4811-a83d-bdc8de0f5be4" />


to this:

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/84185e45-bab2-4c73-942f-429623abadb2" />


