### PR TITLE
Emit input value on blur for input components

### DIFF
--- a/src/components/SelectInput.vue
+++ b/src/components/SelectInput.vue
@@ -72,7 +72,7 @@ const onBlur = (evt: ElementEvent<HTMLSelectElement>) => {
     validationMessage.value = '';
   }
 
-  emit('blur');
+  emit('blur', model.value);
 };
 
 defineExpose({ focus, reset });

--- a/src/components/SelectInput.vue
+++ b/src/components/SelectInput.vue
@@ -72,7 +72,7 @@ const onBlur = (evt: ElementEvent<HTMLSelectElement>) => {
     validationMessage.value = '';
   }
 
-  emit('blur', model.value);
+  emit('blur', evt);
 };
 
 defineExpose({ focus, reset });

--- a/src/components/TextArea.vue
+++ b/src/components/TextArea.vue
@@ -90,7 +90,7 @@ const onBlur = (evt: ElementEvent<HTMLTextAreaElement>) => {
     validationMessage.value = '';
   }
 
-  emit('blur', model.value);
+  emit('blur', evt);
 };
 </script>
 

--- a/src/components/TextArea.vue
+++ b/src/components/TextArea.vue
@@ -90,7 +90,7 @@ const onBlur = (evt: ElementEvent<HTMLTextAreaElement>) => {
     validationMessage.value = '';
   }
 
-  emit('blur');
+  emit('blur', model.value);
 };
 </script>
 

--- a/src/components/TextInput.vue
+++ b/src/components/TextInput.vue
@@ -97,7 +97,7 @@ const onBlur = (evt: ElementEvent<HTMLInputElement>) => {
     validationMessage.value = '';
   }
 
-  emit('blur');
+  emit('blur', model.value);
 };
 
 // not computed, we want this only on the initial load

--- a/src/components/TextInput.vue
+++ b/src/components/TextInput.vue
@@ -97,7 +97,7 @@ const onBlur = (evt: ElementEvent<HTMLInputElement>) => {
     validationMessage.value = '';
   }
 
-  emit('blur', model.value);
+  emit('blur', evt);
 };
 
 // not computed, we want this only on the initial load

--- a/test/components/TextArea.test.js
+++ b/test/components/TextArea.test.js
@@ -199,6 +199,12 @@ describe('TextArea', () => {
     expect(wrapper.emitted().change, 'expected change event to have been emitted').toBeTruthy();
     expect(wrapper.emitted()['change'].length).toBe(1);
     expect(textArea.element.value).toBe(inputText);
+
+    // now blur and verify
+    await textArea.trigger('blur');
+    expect(wrapper.emitted().blur, 'expected blur event to have been emitted').toBeTruthy();
+    expect(wrapper.emitted()['blur'].length).toBe(1);
+    expect(wrapper.emitted()['blur'][0][0]).toBe(inputText);
   });
 
   it('able to reset the text area using exposed reset method', async () => {

--- a/test/components/TextArea.test.js
+++ b/test/components/TextArea.test.js
@@ -204,7 +204,7 @@ describe('TextArea', () => {
     await textArea.trigger('blur');
     expect(wrapper.emitted().blur, 'expected blur event to have been emitted').toBeTruthy();
     expect(wrapper.emitted()['blur'].length).toBe(1);
-    expect(wrapper.emitted()['blur'][0][0]).toBe(inputText);
+    expect(wrapper.emitted()['blur'][0][0].target.value).toBe(inputText);
   });
 
   it('able to reset the text area using exposed reset method', async () => {

--- a/test/components/TextInput.test.js
+++ b/test/components/TextInput.test.js
@@ -343,7 +343,7 @@ describe('TextInput', () => {
     await textInput.trigger('blur');
     expect(wrapper.emitted().blur, 'expected blur event to have been emitted').toBeTruthy();
     expect(wrapper.emitted()['blur'].length).toBe(1);
-    expect(wrapper.emitted()['blur'][0][0]).toBe(inputText);
+    expect(wrapper.emitted()['blur'][0][0].target.value).toBe(inputText);
   });
 
   it('able to reset the text input using exposed reset method', async () => {

--- a/test/components/TextInput.test.js
+++ b/test/components/TextInput.test.js
@@ -338,6 +338,12 @@ describe('TextInput', () => {
     expect(wrapper.emitted().change, 'expected change event to have been emitted').toBeTruthy();
     expect(wrapper.emitted()['change'].length).toBe(1);
     expect(textInput.element.value).toBe(inputText);
+
+    // now blur and verify
+    await textInput.trigger('blur');
+    expect(wrapper.emitted().blur, 'expected blur event to have been emitted').toBeTruthy();
+    expect(wrapper.emitted()['blur'].length).toBe(1);
+    expect(wrapper.emitted()['blur'][0][0]).toBe(inputText);
   });
 
   it('able to reset the text input using exposed reset method', async () => {


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->
This change emits/forwards the blur event when blurring a `TextInput`, `TextArea` or `SelectInput` component.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->
Convenience. This makes the current input value available when listening for the blur event.

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->
The SelectInput tests currently miss cases for events. I was too stupid (or too tired) to make it work for now.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->
Closes #279 

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->
None