### PR TITLE
Fix code examples for VisualDivider component

### DIFF
--- a/src/components/VisualDivider.stories.ts
+++ b/src/components/VisualDivider.stories.ts
@@ -11,13 +11,6 @@ const meta: Meta<typeof VisualDivider> = {
   argTypes: {
     type: { control: 'select', options: ['horizontal', 'vertical'] },
   },
-  decorators:
-    // Make it a little more obvious what we're looking at by framing the divider
-    (_, {}) => {
-      return {
-        template: `<section style="width: 256px; height: 256px; padding: 32px; border: 1px lightgrey solid; display: flex; justify-content: center; align-items: center;"><story/></section>`,
-      };
-    },
 };
 export default meta;
 
@@ -27,10 +20,44 @@ export const HorziontalDivider: Story = {
   args: {
     type: 'horizontal',
   },
+  decorators: [
+    (story) => ({
+      components: { story },
+      template: `<section style="width: 50%;">
+        <p>While in recent findings, the interdisciplinary cohort clarifies a contested framework across multiple cohorts, at present, a comparative historian outlines the institutional context through comparative analysis.</p>
+        <story />
+        <p>Because in the study, a peer-reviewed study contextualizes an emergent hypothesis within a broader discourse, at the institutional level, the principal investigator examines a longitudinal dataset across multiple cohorts.</p>
+      </section>`,
+    }),
+  ],
+  parameters: {
+    docs: {
+      source: {
+        code: '<p>While in recent findings...</p>\n<visual-divider type="horizontal" />\n<p>Because in the study...</p>',
+      },
+    },
+  },
 };
 
 export const VerticalDivider: Story = {
   args: {
     type: 'vertical',
+  },
+  decorators: [
+    (story) => ({
+      components: { story },
+      template: `<section style="height: 100px; display: flex; gap: 1rem;">
+        <p>While in recent findings, the interdisciplinary cohort clarifies a contested framework across multiple cohorts, at present, a comparative historian outlines the institutional context through comparative analysis.</p>
+        <story />
+        <p>Because in the study, a peer-reviewed study contextualizes an emergent hypothesis within a broader discourse, at the institutional level, the principal investigator examines a longitudinal dataset across multiple cohorts.</p>
+      </section>`,
+    }),
+  ],
+  parameters: {
+    docs: {
+      source: {
+        code: `<section style="height: 100px; display: flex; gap: 1rem;">\n  <p>While in recent findings...</p>\n  <visual-divider type="vertical" />\n  <p>Because in the study...</p>\n</section>`,
+      },
+    },
   },
 };

--- a/src/components/VisualDivider.vue
+++ b/src/components/VisualDivider.vue
@@ -28,6 +28,7 @@ html {
 .divider {
   box-shadow: 1px 0 0 0 var(--divider-border-colour);
   background-color: var(--divider-background-colour);
+  flex-shrink: 0;
 }
 
 .horizontal {


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->
This change improves the demo code examples and enhances the stories for the `VisualDivider` component. Component names and HTML attributes are now in dash-case. Reactivity for the default story is kept intact. Also the stories got some more text flow context to better visualize the component.

Additionally a style issue was fixed, where the divider disappeared due to flex items letting it shrink.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->
More organized and consistent documentation.

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->
None.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->
Closes #269

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

Before:

<img width="977" height="1135" alt="image" src="https://github.com/user-attachments/assets/eabf33ba-ffaa-4882-b882-4aa8257f657b" />

After:

<img width="953" height="937" alt="image" src="https://github.com/user-attachments/assets/ef9b76e2-8e08-4753-9176-83844e10c4ca" />
