### PR TITLE
Fix NoticeBar component wrap

### DIFF
--- a/src/components/BaseButton.vue
+++ b/src/components/BaseButton.vue
@@ -325,6 +325,7 @@ button:hover > .tooltip {
   box-shadow: none !important;
   border: none !important;
   min-width: 0;
+  padding: 0.5rem 0.75rem;
 
   .text {
     padding: 0;

--- a/src/components/NoticeBar.stories.ts
+++ b/src/components/NoticeBar.stories.ts
@@ -41,8 +41,8 @@ export const CTAControls: Story = {
   render: () => ({
     components: { NoticeBar, PrimaryButton, LinkButton },
     template: `
-      <notice-bar>
-        This form is dirty.
+      <notice-bar type="warning">
+        You have unsaved changes.
 
         <template #cta>
           <link-button>Revert changes</link-button>
@@ -54,7 +54,7 @@ export const CTAControls: Story = {
   parameters: {
     docs: {
       source: {
-        code: '<notice-bar>\n  This form is dirty.\n\n  <template #cta>\n    <link-button>Revert changes</link-button>\n    <primary-button size="small">Save changes</primary-button>\n  </template>\n</notice-bar>',
+        code: '<notice-bar type="warning">\n  You have unsaved changes.\n\n  <template #cta>\n    <link-button>Revert changes</link-button>\n    <primary-button size="small">Save changes</primary-button>\n  </template>\n</notice-bar>',
       },
     },
   },

--- a/src/components/NoticeBar.vue
+++ b/src/components/NoticeBar.vue
@@ -25,15 +25,17 @@ const isError = computed(() => props.type === NoticeBarTypes.Critical);
 
 <template>
   <div :class="{ [type]: type }" class="notice notice-bar" :data-testid="dataTestid">
-    <span class="icon">
-      <notice-info-icon v-if="isInfo" />
-      <notice-success-icon v-if="isSuccess" />
-      <notice-warning-icon v-if="isWarning" />
-      <notice-critical-icon v-if="isError" />
-    </span>
-    <span class="body">
-      <slot />
-    </span>
+    <div class="notice-bar-content">
+      <span class="icon">
+        <notice-info-icon v-if="isInfo" />
+        <notice-success-icon v-if="isSuccess" />
+        <notice-warning-icon v-if="isWarning" />
+        <notice-critical-icon v-if="isError" />
+      </span>
+      <span class="body">
+        <slot />
+      </span>
+    </div>
     <div class="cta" v-if="$slots?.cta">
       <slot name="cta" />
     </div>
@@ -43,18 +45,41 @@ const isError = computed(() => props.type === NoticeBarTypes.Critical);
 <style scoped>
 @import '@/assets/styles/custom-media.pcss';
 
-.icon {
+.notice {
   display: flex;
+  justify-content: space-between;
   align-items: center;
-  justify-content: center;
+  border-radius: 1rem;
+  border: 0.0625rem solid;
+  padding: 1rem;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+
+  &:has(.cta) {
+    padding: 0.75rem 0.75rem 0.75rem 1rem;
+  }
 }
 
-.body {
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 132%;
-  color: var(--colour-ti-secondary);
-  flex-grow: 1;
+.notice-bar-content {
+  display: flex;
+  align-items: center;
+  justify-content: start;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+
+  .icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .body {
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 132%;
+    color: var(--colour-ti-secondary);
+    flex-grow: 1;
+  }
 }
 
 .cta {
@@ -62,21 +87,7 @@ const isError = computed(() => props.type === NoticeBarTypes.Critical);
   align-items: center;
   justify-content: center;
   gap: 1rem;
-}
-
-.notice {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  justify-content: start;
-  align-items: center;
-  border-radius: 1rem;
-  gap: 0.5rem;
-  border: 0.0625rem solid;
-  padding: 1rem;
-
-  &:has(.cta) {
-    padding: 0.75rem 0.75rem 0.75rem 1rem;
-  }
+  flex-wrap: wrap;
 }
 
 .info {


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- Updated `NoticeBar` component to use flex and flex-wrap instead of grid + media queries so that it wraps up it's content nicely.
- Updated `BaseButton` component's `Link` variant to have less padding as it has always been larger than it should affecting surrounding components (NoticeBar grew in height with a Link button within it).

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

NoticeBar had not been coded with responsiveness in mind and would break in smaller viewports. Also, the Link button had a larger padding that wasn't revised until now. 

## Limitations & Notes

This is not an official solve by the Design team but since they are focused on ESR at the moment and this is lower priority, it can be an intermediate solve.

That said, if there's a preference on a variant of this solution, I'd love to consider and apply here!

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Related with https://github.com/thunderbird/appointment/issues/1718
Closes https://github.com/thunderbird/services-ui/issues/293

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->


Video of responsiveness



https://github.com/user-attachments/assets/ed91ec29-e81c-4701-b5ca-1e22cf60a626



