### PR TITLE
Make button height independent from state and content

### DIFF
--- a/src/components/BaseButton.stories.ts
+++ b/src/components/BaseButton.stories.ts
@@ -29,6 +29,8 @@ const meta: Meta<typeof BaseButton> = {
     /* @ts-ignore */
     onClick: fn(),
     default: 'Click me!',
+    disabled: false,
+    forceTooltip: false,
   },
 };
 

--- a/src/components/BaseButton.vue
+++ b/src/components/BaseButton.vue
@@ -177,9 +177,8 @@ button:hover > .tooltip {
     }
 
     &:disabled {
-      --button-outline-border: transparent;
+      --button-outline-border: var(--colour-neutral-border);
       background: var(--colour-neutral-base);
-      border: 0.0625rem solid var(--colour-neutral-border);
       color: var(--colour-ti-muted);
       cursor: not-allowed;
     }
@@ -348,6 +347,10 @@ button:hover > .tooltip {
     background: none;
     color: var(--colour-ti-muted);
     cursor: not-allowed;
+  }
+
+  &.outline:disabled {
+    --button-outline-border: transparent;
   }
 }
 

--- a/src/components/BaseButton.vue
+++ b/src/components/BaseButton.vue
@@ -103,13 +103,15 @@ button:hover > .tooltip {
   align-items: center;
   gap: 0.5rem;
 
+  height: 2.875rem;
+
   border: 0;
   border-radius: var(--border-radius);
   font-family: 'Inter', sans-serif;
   font-size: var(--txt-input); /* 14px */
   font-weight: 400;
   line-height: 1;
-  padding: 1rem 1.12rem;
+  padding: 0 1.12rem;
   cursor: pointer;
   user-select: none;
 
@@ -350,7 +352,8 @@ button:hover > .tooltip {
 }
 
 .small {
-  padding: 0.38rem 0.75rem;
+  height: 1.75rem;
+  padding: 0 0.75rem;
 
   &.brand .text {
     font-size: 0.6875rem;
@@ -360,7 +363,7 @@ button:hover > .tooltip {
     font-size: 0.875rem;
   }
 
-  &button {
+  & button {
     min-width: initial;
     height: 2rem;
   }

--- a/src/components/BaseButton.vue
+++ b/src/components/BaseButton.vue
@@ -326,7 +326,6 @@ button:hover > .tooltip {
   box-shadow: none !important;
   border: none !important;
   min-width: 0;
-  padding: 0.5rem 0.75rem;
 
   .text {
     padding: 0;


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->
This change introduces a fixed height for buttons and eliminates the top and bottom padding, making their height independent from states and content height.

For example having different sized icons now results in buttons with the same height:
<img width="285" height="91" alt="image" src="https://github.com/user-attachments/assets/a36f660d-19f0-44a4-8362-1e399d9c6b25" />

The same goes for buttons using borders (outline variant) or gradient outlines (brand buttons) in combination with disabled state.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->
Visual consistency.

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->
This change won't let buttons grow in height with their contents anymore. We never explicitly supported that, but if somebody used "oversized" buttons, this change would reduce their buttons to the standard button height again.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->
Closes #287 

