### PR TITLE
Fix IconButton height

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import importPlugin from 'eslint-plugin-import';
 import playwright from 'eslint-plugin-playwright';
 import storybook from 'eslint-plugin-storybook';
 import vueLint from 'eslint-plugin-vue';
+import globals from 'globals';
 import { defineConfigWithVueTs, vueTsConfigs } from '@vue/eslint-config-typescript';
 
 export default defineConfigWithVueTs(
@@ -14,14 +15,12 @@ export default defineConfigWithVueTs(
   vueTsConfigs.recommended,
   ...storybook.configs['flat/recommended'],
   {
-    ...playwright.configs['flat/recommended'],
     files: ['**/*.vue', '**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs', '**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',
     },
     rules: {
-      ...playwright.configs['flat/recommended'].rules,
       'import/extensions': [
         'error',
         'ignorePackages',
@@ -57,5 +56,17 @@ export default defineConfigWithVueTs(
         node: true,
       },
     },
+  },
+  {
+    files: ['test/**/*.js', 'test/**/*.ts'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+      },
+    },
+  },
+  {
+    ...playwright.configs['flat/recommended'],
+    files: ['e2e/**'],
   }
 );

--- a/src/components/IconButton.vue
+++ b/src/components/IconButton.vue
@@ -20,6 +20,7 @@ withDefaults(defineProps<Props>(), {
 <style>
 .link.icon-only {
   padding: 0.5rem;
+  height: auto;
 
   .icon,
   .icon svg {

--- a/test/components/IconButton.test.js
+++ b/test/components/IconButton.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach, beforeAll } from 'vitest';
+import { mount } from '@vue/test-utils';
+import IconButton from '@/components/IconButton.vue';
+import RefreshIcon from '@/foundation/RefreshIcon.vue';
+import {
+  expectDimensionNear,
+  injectComponentStyles,
+  remToPx,
+  setRootFontSize,
+} from '../utils';
+
+const sizeExpectations = [
+  { size: 'small', expectedRem: 0.75 },
+  { size: 'default', expectedRem: 1 },
+  { size: 'medium', expectedRem: 1.25 },
+  { size: 'large', expectedRem: 1.5 },
+];
+
+const BASE_BUTTON_HEIGHT_PX = remToPx(2.875);
+
+describe('IconButton', () => {
+  let wrapper;
+
+  beforeAll(async () => {
+    setRootFontSize();
+    await injectComponentStyles('src/components/BaseButton.vue');
+    await injectComponentStyles('src/components/IconButton.vue');
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it.each(sizeExpectations)(
+    'renders icon at expected size for size="$size"',
+    ({ size, expectedRem }) => {
+      const expectedPx = remToPx(expectedRem);
+
+      wrapper = mount(IconButton, {
+        props: { size },
+        slots: {
+          default: RefreshIcon,
+        },
+        attachTo: document.body,
+      });
+
+      const iconSvg = wrapper.find('.icon svg');
+      expect(iconSvg.exists()).toBe(true);
+
+      const styles = getComputedStyle(iconSvg.element);
+      expectDimensionNear(parseFloat(styles.width), expectedPx);
+      expectDimensionNear(parseFloat(styles.height), expectedPx);
+    },
+  );
+
+  it('uses auto height instead of the fixed BaseButton height', () => {
+    wrapper = mount(IconButton, {
+      slots: {
+        default: RefreshIcon,
+      },
+      attachTo: document.body,
+    });
+
+    const buttonStyles = getComputedStyle(wrapper.find('.base').element);
+    expect(buttonStyles.height).toBe('auto');
+    expect(parseFloat(buttonStyles.height)).not.toBe(BASE_BUTTON_HEIGHT_PX);
+  });
+
+  it('hides button label text', () => {
+    wrapper = mount(IconButton, {
+      slots: {
+        default: RefreshIcon,
+      },
+      attachTo: document.body,
+    });
+
+    const textStyles = getComputedStyle(wrapper.find('.text').element);
+    expect(textStyles.display).toBe('none');
+  });
+});

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import postcss from 'postcss';
+import postcssNesting from 'postcss-nesting';
+import { expect } from 'vitest';
+
+export const ROOT_FONT_SIZE_PX = 16;
+export const TOLERANCE_PX = 1;
+
+export function remToPx(rem: number): number {
+  return rem * ROOT_FONT_SIZE_PX;
+}
+
+export function expectDimensionNear(actual: number, expectedPx: number, tolerancePx = TOLERANCE_PX): void {
+  expect(Math.abs(actual - expectedPx)).toBeLessThanOrEqual(tolerancePx);
+}
+
+export function setRootFontSize(fontSizePx = ROOT_FONT_SIZE_PX): void {
+  document.documentElement.style.fontSize = `${fontSizePx}px`;
+}
+
+export async function injectComponentStyles(relativePath: string): Promise<void> {
+  const source = readFileSync(resolve(relativePath), 'utf8');
+  const styleBlocks = [...source.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)];
+
+  if (styleBlocks.length === 0) {
+    throw new Error(`No <style> block found in ${relativePath}`);
+  }
+
+  for (const [, styleContent] of styleBlocks) {
+    const css = await postcss([postcssNesting]).process(styleContent, { from: undefined });
+    const style = document.createElement('style');
+    style.textContent = css.css;
+    document.head.appendChild(style);
+  }
+}


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- IconButton has a `height: auto` now
- Updated ESLint config so functions inside .test.js components are parsed correctly
- Add IconButton tests

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

We've accidentally introduced a regression on the IconButton component when fixing the height of the base button (https://github.com/thunderbird/services-ui/pull/296)

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Closes https://github.com/thunderbird/services-ui/issues/297

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

Before


https://github.com/user-attachments/assets/f669154e-8dba-4eb3-88f3-8ca2fd09e208



After

https://github.com/user-attachments/assets/c921d8f4-efae-49a9-be52-c0f57c7bc9fc



