### PR TITLE
Rotate dropdown caret when opening SelectInput

### DIFF
--- a/src/components/SelectInput.vue
+++ b/src/components/SelectInput.vue
@@ -180,6 +180,7 @@ defineExpose({ focus, reset });
     width: 1.25rem;
     height: 1.25rem;
     pointer-events: none;
+    transition: transform 250ms ease-in-out;
   }
 }
 
@@ -224,6 +225,10 @@ defineExpose({ focus, reset });
   &.dirty:invalid:not(:focus),
   &.error:not(:focus) {
     border-color: var(--colour-ti-critical);
+  }
+
+  &:open ~ .dropdown-caret {
+    transform: rotate(180deg);
   }
 }
 

--- a/test/components/SelectInput.test.js
+++ b/test/components/SelectInput.test.js
@@ -142,7 +142,7 @@ describe('SelectInput', () => {
     });
   });
 
-  it('able to select an option', async () => {
+  it('can select an option', async () => {
     const ourProps = {
       name: 'standard',
       label: 'Please select an option',
@@ -170,7 +170,7 @@ describe('SelectInput', () => {
     expect(selInput.element.value).toBe(options[0]['value']);
   });
 
-  it('unable to select an option when disabled', async () => {
+  it('cannot select an option when disabled', async () => {
     const ourProps = {
       name: 'standard',
       label: 'Please select an option',
@@ -198,7 +198,7 @@ describe('SelectInput', () => {
     expect(wrapper.emitted().click, 'expected click event to have been emitted').toBeFalsy();
   });
 
-  it('able to reset the selected input using exposed reset method', async () => {
+  it('resets the selected input using exposed reset method', async () => {
     const ourProps = {
       name: 'standard',
       label: 'Please select an option',


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->
This change fixes a UI inconsistency so that the dropdown caret now rotates and points upwards when the SelectInput component is opened.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->
Visual state indication.

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->
This relies on the [`:open` CSS pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:open), which recently got baseline support. I didn't find a good approach to test this, so I skipped adding a test for now.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->
Closes #225 

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

https://github.com/user-attachments/assets/56a580ab-e049-485b-a549-848437bcc965

