### PR TITLE
Fix SelectInput initially requiring selecting an option twice in Chrome / Safari

### DIFF
--- a/src/components/SelectInput.vue
+++ b/src/components/SelectInput.vue
@@ -59,7 +59,7 @@ const onInvalid = (evt: Event) => {
   isInvalid.value = true;
   validationMessage.value = (evt as ElementEvent<HTMLSelectElement>).target.validationMessage;
 };
-const onInput = () => {
+const onChange = () => {
   isDirty.value = true;
   isInvalid.value = false;
   validationMessage.value = '';
@@ -94,7 +94,7 @@ defineExpose({ focus, reset });
         :id="name"
         :name="name"
         @invalid="onInvalid"
-        @input="onInput"
+        @change="onChange"
         @blur="onBlur"
         :data-testid="dataTestid"
         ref="inputRef"


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

Using @change instead of @input for SelectInput

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

[According to Evan You himself](https://github.com/vuejs/vue/issues/6690#issuecomment-334340826), we should be doing this for select for cross-browser compatibility as apparently `IE and Edge do not trigger input on <select> elements`.

## How to test

- Run the storybook locally (or get the artifact)
- Open any SelectInput story in Safari / Chrome
- Check that it behaves normally now instead of requiring selecting the option twice

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Closes https://github.com/thunderbird/services-ui/issues/304
Related with https://github.com/thunderbird/thunderbird-accounts/issues/819

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

https://github.com/user-attachments/assets/af93112e-239c-469a-997f-10c74723a76d


