### PR TITLE
Use node version 24 instead for CI workflows

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v4.0.3
         with:
+          node-version: '24'
           cache: npm
 
       - name: Install Deps

--- a/.github/workflows/export-storybook-artifact.yml
+++ b/.github/workflows/export-storybook-artifact.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v4.0.3
         with:
+          node-version: '24'
           cache: npm
 
       - name: Install Deps

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Update npm

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v4.0.3
         with:
+          node-version: '24'
           cache: npm
 
       - name: Install Deps


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- Pinning node v24 in CI workflows

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

- The `publish-node` CI workflow fails as it was using a deprecated node version: https://github.com/thunderbird/services-ui/actions/runs/29263632741/job/86863463552
